### PR TITLE
Add percent parsing for Lab and Lch

### DIFF
--- a/src/util/regex.js
+++ b/src/util/regex.js
@@ -8,27 +8,39 @@
 
 const num = (/([+-]?\d*\.?\d+(?:[eE][+-]?\d+)?)/ + '').replace(/^\/|\/$/g, ''); // number
 const per = `${num}%`; // percentage
+const per_or_num = `${num}%?`; // percentage or number
 const alpha = `(?:${num}%|${num})`; // alpha-value
 const hue = `(?:${num}(deg|grad|rad|turn)|${num})`; // hue
 const c = `\\s*,\\s*`; // comma
 const s = `\\s+`; // space
 
-
 /*
 	rgb() regular expressions.
 	Reference: https://drafts.csswg.org/css-color/#rgb-functions
  */
-const rgb_num_old = new RegExp(`^rgba?\\(\\s*${num}${c}${num}${c}${num}\\s*(?:,\\s*${alpha}\\s*)?\\)$`);
-const rgb_per_old = new RegExp(`^rgba?\\(\\s*${per}${c}${per}${c}${per}\\s*(?:,\\s*${alpha}\\s*)?\\)$`);
-const rgb_num_new = new RegExp(`^rgba?\\(\\s*${num}${s}${num}${s}${num}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`);
-const rgb_per_new = new RegExp(`^rgba?\\(\\s*${per}${s}${per}${s}${per}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`);
+const rgb_num_old = new RegExp(
+	`^rgba?\\(\\s*${num}${c}${num}${c}${num}\\s*(?:,\\s*${alpha}\\s*)?\\)$`
+);
+const rgb_per_old = new RegExp(
+	`^rgba?\\(\\s*${per}${c}${per}${c}${per}\\s*(?:,\\s*${alpha}\\s*)?\\)$`
+);
+const rgb_num_new = new RegExp(
+	`^rgba?\\(\\s*${num}${s}${num}${s}${num}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`
+);
+const rgb_per_new = new RegExp(
+	`^rgba?\\(\\s*${per}${s}${per}${s}${per}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`
+);
 
 /*
 	hsl() regular expressions.
 	Reference: https://drafts.csswg.org/css-color/#the-hsl-notation
  */
-const hsl_old = new RegExp(`^hsla?\\(\\s*${hue}${c}${per}${c}${per}\\s*(?:,\\s*${alpha}\\s*)?\\)$`);
-const hsl_new = new RegExp(`^hsla?\\(\\s*${hue}${s}${per}${s}${per}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`);
+const hsl_old = new RegExp(
+	`^hsla?\\(\\s*${hue}${c}${per}${c}${per}\\s*(?:,\\s*${alpha}\\s*)?\\)$`
+);
+const hsl_new = new RegExp(
+	`^hsla?\\(\\s*${hue}${s}${per}${s}${per}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`
+);
 
 /*
 	hexadecimal regular expressions.
@@ -39,20 +51,28 @@ const hex = /^#?([0-9a-f]{8}|[0-9a-f]{6}|[0-9a-f]{4}|[0-9a-f]{3})$/i;
 	hwb() regular expressions.
 	Reference: https://drafts.csswg.org/css-color/#the-hwb-notation
  */
-const hwb = new RegExp(`^hwb\\(\\s*${hue}${s}${per}${s}${per}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`);
+const hwb = new RegExp(
+	`^hwb\\(\\s*${hue}${s}${per}${s}${per}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`
+);
 
 /*
 	lab() and lch() regular expressions.
 	Reference: https://drafts.csswg.org/css-color/#lab-colors
  */
-const lab = new RegExp(`^lab\\(\\s*${num}${s}${num}${s}${num}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`);
-const lch = new RegExp(`^lch\\(\\s*${num}${s}${num}${s}${hue}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`);
+const lab = new RegExp(
+	`^lab\\(\\s*${per_or_num}${s}${num}${s}${num}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`
+);
+const lch = new RegExp(
+	`^lch\\(\\s*${per_or_num}${s}${num}${s}${hue}\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`
+);
 
 /*
 	gray() regular expressions.
 	Reference: https://drafts.csswg.org/css-color/#grays
  */
-const gray = new RegExp(`^gray\\(\\s*${num}()()\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`);
+const gray = new RegExp(
+	`^gray\\(\\s*${num}()()\\s*(?:\\/\\s*${alpha}\\s*)?\\)$`
+);
 
 export {
 	rgb_num_old,

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -271,6 +271,12 @@ tape('lab()', function(test) {
 		'gray + alpha'
 	);
 
+	test.deepEqual(
+		parse('lab(50% -5 10)'),
+		{ l: 50, a: -5, b: 10, mode: 'lab' },
+		'lab with percentage'
+	);
+
 	test.end();
 });
 
@@ -285,6 +291,12 @@ tape('lch()', function(test) {
 		parse('lch(50 -3 240deg / 50%)'),
 		{ l: 50, c: 0, h: 240, alpha: 0.5, mode: 'lch' },
 		'lch negative c'
+	);
+
+	test.deepEqual(
+		parse('lch(50% 3 240)'),
+		{ l: 50, c: 3, h: 240, mode: 'lch' },
+		'lch with percentage'
 	);
 
 	test.end();


### PR DESCRIPTION
As the specification states, lab and lch should accept a percentage as first argument [source](https://drafts.csswg.org/css-color/#specifying-lab-lch).

Line 11, 63 and 66 in ` src/util/regex.js` were modified to handle percentage.

The other lines are modified by the linter.

Tests were added to make sure percentage parsing was handled.
