### PR TITLE
Add CIELab D65 (cartesian + polar), switch DIN99o to D65

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -80,11 +80,13 @@ The available modes (color spaces) are listed below. For convenience, each color
 | `hwb`       | HWB color space                                        | culori.**hwb**(_color_)       |
 | `jab`       | JzAzBz color space                                     | culori.**jab**(_color_)       |
 | `jch`       | JzAzBz in polar form                                   | culori.**jch**(_color_)       |
-| `lab`       | Lab color space (D50)                                  | culori.**lab**(_color_)       |
-| `lch`       | LCh color space (D50)                                  | culori.**lch**(_color_)       |
-| `lchuv`     | CIELCHuv color space                                   | culori.**lchuv**(_color_)     |
+| `lab`       | Lab color space (D50 Illuminant)                       | culori.**lab**(_color_)       |
+| `lab65`     | Lab color space (D65 Illuminant)                       | culori.**lab65**(_color_)     |
+| `lch`       | LCh color space (D50 Illuminant)                       | culori.**lch**(_color_)       |
+| `lch65`     | LCh color space (D65 Illuminant)                       | culori.**lch65**(_color_)     |
+| `lchuv`     | CIELCHuv color space (D50 Illuminant)                  | culori.**lchuv**(_color_)     |
 | `lrgb`      | Linear-light sRGB color space                          | culori.**lrgb**(_color_)      |
-| `luv`       | CIELuv color space                                     | culori.**luv**(_color_)       |
+| `luv`       | CIELuv color space (D50 Illuminant)                    | culori.**luv**(_color_)       |
 | `p3`        | Display P3 color space                                 | culori.**p3**(_color_)        |
 | `prophoto`  | ProPhoto RGB color space                               | culori.**prophoto**(_color_)  |
 | `rec2020`   | Rec. 2020 RGB color space                              | culori.**rec2020**(_color_)   |

--- a/docs/color-spaces.md
+++ b/docs/color-spaces.md
@@ -114,6 +114,14 @@ The figure below shows a slice of the HSI color space for a particular hue:
 
 > 💡 The range for the `a` and `b` channels in Lab, and the `c` channel in LCh, depend on the specific implementation. I've obtained the ranges from the tables above by converting all sRGB colors defined by `r, g, b ∈ ℕ ⋂ [0, 255]` into Lab and LCh respectively.
 
+### `lab65`
+
+CIELab that uses the D65 illuminant.
+
+### `lch65`
+
+CIELCh that uses the D65 illuminant.
+
 ## Luv / LCHuv (CIE)
 
 [CIELuv color space](https://en.wikipedia.org/wiki/CIELUV) in cartesian and polar forms, using the D50 standard illuminant.

--- a/docs/color-spaces.md
+++ b/docs/color-spaces.md
@@ -116,11 +116,23 @@ The figure below shows a slice of the HSI color space for a particular hue:
 
 ### `lab65`
 
-CIELab that uses the D65 illuminant.
+CIELab relative to the D65 illuminant.
+
+| Channel | Range               | Description           |
+| ------- | ------------------- | --------------------- |
+| `l`     | `[0, 100]`          | Lightness             |
+| `a`     | `[-86.183, 98.234]` | Green–red component   |
+| `b`     | `[-107.86, 94.478]` | Blue–yellow component |
 
 ### `lch65`
 
-CIELCh that uses the D65 illuminant.
+CIELCh relative to the D65 illuminant.
+
+| Channel | Range          | Description |
+| ------- | -------------- | ----------- |
+| `l`     | `[0, 100]`     | Lightness   |
+| `c`     | `[0, 133.807]` | Chroma      |
+| `h`     | `[0, 360)`     | Hue         |
 
 ## Luv / LCHuv (CIE)
 
@@ -154,18 +166,18 @@ The [DIN99][din99o] color space "squishes" the CIE Lab color space to obtain an 
 
 ### `dlab`
 
-| Channel | Range               | Description |
-| ------- | ------------------- | ----------- |
-| `l`     | `[0, 100]`          | Lightness   |
-| `a`     | `[-39.229, 45.166]` |
-| `b`     | `[-43.002, 44.424]` |
+| Channel | Range              | Description |
+| ------- | ------------------ | ----------- |
+| `l`     | `[0, 100]`         | Lightness   |
+| `a`     | `[-40.09, 45.5]`   |
+| `b`     | `[-40.47, 44.344]` |
 
 ### `dlch`
 
 | Channel | Range         | Description |
 | ------- | ------------- | ----------- |
 | `l`     | `[0, 100]`    | Lightness   |
-| `c`     | `[0, 50.944]` | Chroma      |
+| `c`     | `[0, 51.484]` | Chroma      |
 | `h`     | `[0, 360)`    | Hue         |
 
 **References:**

--- a/src/dlab/convertDlabToLab.js
+++ b/src/dlab/convertDlabToLab.js
@@ -1,4 +1,0 @@
-import convertDlabToDlch from '../dlch/convertDlabToDlch';
-import convertDlchToLab from '../dlch/convertDlchToLab';
-
-export default c => convertDlchToLab(convertDlabToDlch(c));

--- a/src/dlab/convertDlabToLab65.js
+++ b/src/dlab/convertDlabToLab65.js
@@ -1,0 +1,4 @@
+import convertDlabToDlch from '../dlch/convertDlabToDlch';
+import convertDlchToLab65 from '../dlch/convertDlchToLab65';
+
+export default c => convertDlchToLab65(convertDlabToDlch(c));

--- a/src/dlab/convertDlabToRgb.js
+++ b/src/dlab/convertDlabToRgb.js
@@ -1,4 +1,0 @@
-import convertLabToRgb from '../lab/convertLabToRgb';
-import convertDlabToLab from './convertDlabToLab';
-
-export default c => convertLabToRgb(convertDlabToLab(c));

--- a/src/dlab/convertLab65ToDlab.js
+++ b/src/dlab/convertLab65ToDlab.js
@@ -1,0 +1,4 @@
+import convertLab65ToDlch from '../dlch/convertLab65ToDlch';
+import convertDlchToDlab from '../dlch/convertDlchToDlab';
+
+export default c => convertDlchToDlab(convertLab65ToDlch(c));

--- a/src/dlab/convertLabToDlab.js
+++ b/src/dlab/convertLabToDlab.js
@@ -1,4 +1,0 @@
-import convertLabToDlch from '../dlch/convertLabToDlch';
-import convertDlchToDlab from '../dlch/convertDlchToDlab';
-
-export default c => convertDlchToDlab(convertLabToDlch(c));

--- a/src/dlab/convertRgbToDlab.js
+++ b/src/dlab/convertRgbToDlab.js
@@ -1,4 +1,0 @@
-import convertRgbToLab from '../lab/convertRgbToLab';
-import convertLabToDlab from './convertLabToDlab';
-
-export default c => convertLabToDlab(convertRgbToLab(c));

--- a/src/dlab/definition.js
+++ b/src/dlab/definition.js
@@ -18,8 +18,8 @@ export default {
 	channels: ['l', 'a', 'b', 'alpha'],
 	ranges: {
 		l: [0, 100],
-		a: [-39.229, 45.166],
-		b: [-43.002, 44.424]
+		a: [-40.09, 45.5],
+		b: [-40.47, 44.344]
 	},
 	interpolate: {
 		l: interpolatorLinear,

--- a/src/dlab/definition.js
+++ b/src/dlab/definition.js
@@ -1,19 +1,19 @@
-import convertDlabToLab from './convertDlabToLab';
-import convertDlabToRgb from './convertDlabToRgb';
-import convertLabToDlab from './convertLabToDlab';
-import convertRgbToDlab from './convertRgbToDlab';
+import convertDlabToLab65 from './convertDlabToLab65';
+import convertLab65ToDlab from './convertLab65ToDlab';
+import convertLab65ToRgb from '../lab65/convertLab65ToRgb';
+import convertRgbToLab65 from '../lab65/convertRgbToLab65';
 import { interpolatorLinear } from '../interpolate/linear';
 import { fixupAlpha } from '../fixup/alpha';
 
 export default {
 	mode: 'dlab',
 	output: {
-		lab: convertDlabToLab,
-		rgb: convertDlabToRgb
+		lab65: convertDlabToLab65,
+		rgb: c => convertLab65ToRgb(convertDlabToLab65(c))
 	},
 	input: {
-		lab: convertLabToDlab,
-		rgb: convertRgbToDlab
+		lab65: convertLab65ToDlab,
+		rgb: c => convertLab65ToDlab(convertRgbToLab65(c))
 	},
 	channels: ['l', 'a', 'b', 'alpha'],
 	ranges: {

--- a/src/dlch/convertDlchToLab65.js
+++ b/src/dlch/convertDlchToLab65.js
@@ -1,27 +1,26 @@
 import { kCH, kE, sinθ, cosθ, θ, factor } from './constants';
 
 /*
-	Convert DIN99oLCh to CIELab
-	---------------------------
+	Convert DIN99o LCh to CIELab D65
+	--------------------------------
  */
 
 export default ({ l, c, h, alpha }) => {
-
 	let res = {
-		mode: 'lab',
-		l: (Math.exp(l * kE / factor) - 1) / 0.0039
-	}
+		mode: 'lab65',
+		l: (Math.exp((l * kE) / factor) - 1) / 0.0039
+	};
 
 	if (h === undefined) {
 		res.a = res.b = 0;
 	} else {
 		let G = (Math.exp(0.0435 * c * kCH * kE) - 1) / 0.075;
-		let e = G * Math.cos(h / 180 * Math.PI - θ);
-		let f = G * Math.sin(h / 180 * Math.PI - θ);
+		let e = G * Math.cos((h / 180) * Math.PI - θ);
+		let f = G * Math.sin((h / 180) * Math.PI - θ);
 		res.a = e * cosθ - (f / 0.83) * sinθ;
 		res.b = e * sinθ + (f / 0.83) * cosθ;
-	};
+	}
 
 	if (alpha !== undefined) res.alpha = alpha;
 	return res;
-}
+};

--- a/src/dlch/convertDlchToRgb.js
+++ b/src/dlch/convertDlchToRgb.js
@@ -1,4 +1,0 @@
-import convertDlchToLab from './convertDlchToLab';
-import convertLabToRgb from '../lab/convertLabToRgb';
-
-export default c => convertLabToRgb(convertDlchToLab(c));

--- a/src/dlch/convertLab65ToDlch.js
+++ b/src/dlch/convertLab65ToDlch.js
@@ -1,7 +1,8 @@
 import { kCH, kE, sinθ, cosθ, θ, factor } from './constants';
 
 /*
-	Convert CIELab to DIN99o LCh
+	Convert CIELab D65 to DIN99o LCh
+	================================
  */
 
 export default ({ l, a, b, alpha }) => {

--- a/src/dlch/convertLab65ToDlch.js
+++ b/src/dlch/convertLab65ToDlch.js
@@ -1,4 +1,5 @@
 import { kCH, kE, sinθ, cosθ, θ, factor } from './constants';
+import normalizeHue from '../util/normalizeHue';
 
 /*
 	Convert CIELab D65 to DIN99o LCh
@@ -16,7 +17,7 @@ export default ({ l, a, b, alpha }) => {
 	};
 
 	if (res.c) {
-		res.h = ((Math.atan2(f, e) + θ) / Math.PI) * 180;
+		res.h = normalizeHue(((Math.atan2(f, e) + θ) / Math.PI) * 180);
 	}
 
 	if (alpha !== undefined) res.alpha = alpha;

--- a/src/dlch/convertRgbToDlch.js
+++ b/src/dlch/convertRgbToDlch.js
@@ -1,4 +1,0 @@
-import convertRgbToLab from '../lab/convertRgbToLab';
-import convertLabToDlch from './convertLabToDlch';
-
-export default c => convertLabToDlch(convertRgbToLab(c));

--- a/src/dlch/definition.js
+++ b/src/dlch/definition.js
@@ -26,7 +26,7 @@ export default {
 	channels: ['l', 'c', 'h', 'alpha'],
 	ranges: {
 		l: [0, 100],
-		c: [0, 50.944],
+		c: [0, 51.484],
 		h: [0, 360]
 	},
 	interpolate: {

--- a/src/dlch/definition.js
+++ b/src/dlch/definition.js
@@ -1,10 +1,9 @@
-import convertDlchToDlab from './convertDlchToDlab';
-import convertDlchToLab from './convertDlchToLab';
-import convertDlchToRgb from './convertDlchToRgb';
-
-import convertLabToDlch from './convertLabToDlch';
 import convertDlabToDlch from './convertDlabToDlch';
-import convertRgbToDlch from './convertRgbToDlch';
+import convertDlchToDlab from './convertDlchToDlab';
+import convertDlchToLab65 from './convertDlchToLab65';
+import convertLab65ToDlch from './convertLab65ToDlch';
+import convertLab65ToRgb from '../lab65/convertLab65ToRgb';
+import convertRgbToLab65 from '../lab65/convertRgbToLab65';
 
 import { fixupHueShorter } from '../fixup/hue';
 import { fixupAlpha } from '../fixup/alpha';
@@ -15,14 +14,14 @@ import { averageAngle } from '../average';
 export default {
 	mode: 'dlch',
 	output: {
-		lab: convertDlchToLab,
+		lab65: convertDlchToLab65,
 		dlab: convertDlchToDlab,
-		rgb: convertDlchToRgb
+		rgb: c => convertLab65ToRgb(convertDlchToLab65(c))
 	},
 	input: {
-		lab: convertLabToDlch,
+		lab65: convertLab65ToDlch,
 		dlab: convertDlabToDlch,
-		rgb: convertRgbToDlch
+		rgb: c => convertLab65ToDlch(convertRgbToLab65(c))
 	},
 	channels: ['l', 'c', 'h', 'alpha'],
 	ranges: {

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,9 @@ import hwbDef from './hwb/definition';
 import jabDef from './jab/definition';
 import jchDef from './jch/definition';
 import labDef from './lab/definition';
+import lab65Def from './lab65/definition';
 import lchDef from './lch/definition';
+import lch65Def from './lch65/definition';
 import luvDef from './luv/definition';
 import lchuvDef from './lchuv/definition';
 import cubehelixDef from './cubehelix/definition';
@@ -35,7 +37,9 @@ defineMode(hwbDef);
 defineMode(jabDef);
 defineMode(jchDef);
 defineMode(labDef);
+defineMode(lab65Def);
 defineMode(lchDef);
+defineMode(lch65Def);
 defineMode(lchuvDef);
 defineMode(lrgbDef);
 defineMode(luvDef);
@@ -58,7 +62,9 @@ let hwb = converter('hwb');
 let jab = converter('jab');
 let jch = converter('jch');
 let lab = converter('lab');
+let lab65 = converter('lab65');
 let lch = converter('lch');
+let lch65 = converter('lch65');
 let lchuv = converter('lchuv');
 let lrgb = converter('lrgb');
 let luv = converter('luv');
@@ -84,7 +90,9 @@ export {
 	jab,
 	jch,
 	lab,
+	lab65,
 	lch,
+	lch65,
 	lchuv,
 	lrgb,
 	luv,

--- a/src/lab65/convertLab65ToRgb.js
+++ b/src/lab65/convertLab65ToRgb.js
@@ -1,0 +1,4 @@
+import convertLab65ToXyz65 from './convertLab65ToXyz65';
+import convertXyz65ToRgb from '../xyz65/convertXyz65ToRgb';
+
+export default lab => convertXyz65ToRgb(convertLab65ToXyz65(lab));

--- a/src/lab65/convertLab65ToXyz65.js
+++ b/src/lab65/convertLab65ToXyz65.js
@@ -1,0 +1,22 @@
+import { Xn, Yn, Zn, k, e } from '../xyz65/constants';
+
+let fn = v => (Math.pow(v, 3) > e ? Math.pow(v, 3) : (116 * v - 16) / k);
+
+export default ({ l, a, b, alpha }) => {
+	let fy = (l + 16) / 116;
+	let fx = a / 500 + fy;
+	let fz = fy - b / 200;
+
+	let res = {
+		mode: 'xyz65',
+		x: fn(fx) * Xn,
+		y: fn(fy) * Yn,
+		z: fn(fz) * Zn
+	};
+
+	if (alpha !== undefined) {
+		res.alpha = alpha;
+	}
+
+	return res;
+};

--- a/src/lab65/convertRgbToLab65.js
+++ b/src/lab65/convertRgbToLab65.js
@@ -1,0 +1,14 @@
+import convertRgbToXyz65 from '../xyz65/convertRgbToXyz65';
+import convertXyz65ToLab65 from './convertXyz65ToLab65';
+
+export default rgb => {
+	let res = convertXyz65ToLab65(convertRgbToXyz65(rgb));
+
+	// Fixes achromatic RGB colors having a _slight_ chroma due to floating-point errors
+	// and approximated computations in sRGB <-> CIELab.
+	// See: https://github.com/d3/d3-color/pull/46
+	if (rgb.r === rgb.b && rgb.b === rgb.g) {
+		res.a = res.b = 0;
+	}
+	return res;
+};

--- a/src/lab65/convertXyz65ToLab65.js
+++ b/src/lab65/convertXyz65ToLab65.js
@@ -1,0 +1,22 @@
+import { Xn, Yn, Zn, k, e } from '../xyz65/constants';
+
+const f = value => (value > e ? Math.cbrt(value) : (k * value + 16) / 116);
+
+export default ({ x, y, z, alpha }) => {
+	let f0 = f(x / Xn);
+	let f1 = f(y / Yn);
+	let f2 = f(z / Zn);
+
+	let res = {
+		mode: 'lab65',
+		l: 116 * f1 - 16,
+		a: 500 * (f0 - f1),
+		b: 200 * (f1 - f2)
+	};
+
+	if (alpha !== undefined) {
+		res.alpha = alpha;
+	}
+
+	return res;
+};

--- a/src/lab65/definition.js
+++ b/src/lab65/definition.js
@@ -2,10 +2,10 @@ import convertLab65ToRgb from './convertLab65ToRgb';
 import convertLab65ToXyz65 from './convertLab65ToXyz65';
 import convertRgbToLab65 from './convertRgbToLab65';
 import convertXyz65ToLab65 from './convertXyz65ToLab65';
-import { interpolatorLinear } from '../interpolate/linear';
-import { fixupAlpha } from '../fixup/alpha';
+import lab from '../lab/definition';
 
 export default {
+	...lab,
 	mode: 'lab65',
 	alias: ['lab-d65'],
 	output: {
@@ -16,17 +16,10 @@ export default {
 		xyz65: convertXyz65ToLab65,
 		rgb: convertRgbToLab65
 	},
-	channels: ['l', 'a', 'b', 'alpha'],
 	ranges: {
 		l: [0, 100],
-		a: [-79.167, 93.408],
-		b: [-111.859, 93.246]
+		a: [-86.183, 98.234],
+		b: [-107.86, 94.478]
 	},
-	parsers: [],
-	interpolate: {
-		l: interpolatorLinear,
-		a: interpolatorLinear,
-		b: interpolatorLinear,
-		alpha: { use: interpolatorLinear, fixup: fixupAlpha }
-	}
+	parsers: []
 };

--- a/src/lab65/definition.js
+++ b/src/lab65/definition.js
@@ -1,0 +1,32 @@
+import convertLab65ToRgb from './convertLab65ToRgb';
+import convertLab65ToXyz65 from './convertLab65ToXyz65';
+import convertRgbToLab65 from './convertRgbToLab65';
+import convertXyz65ToLab65 from './convertXyz65ToLab65';
+import { interpolatorLinear } from '../interpolate/linear';
+import { fixupAlpha } from '../fixup/alpha';
+
+export default {
+	mode: 'lab65',
+	alias: ['lab-d65'],
+	output: {
+		xyz65: convertLab65ToXyz65,
+		rgb: convertLab65ToRgb
+	},
+	input: {
+		xyz65: convertXyz65ToLab65,
+		rgb: convertRgbToLab65
+	},
+	channels: ['l', 'a', 'b', 'alpha'],
+	ranges: {
+		l: [0, 100],
+		a: [-79.167, 93.408],
+		b: [-111.859, 93.246]
+	},
+	parsers: [],
+	interpolate: {
+		l: interpolatorLinear,
+		a: interpolatorLinear,
+		b: interpolatorLinear,
+		alpha: { use: interpolatorLinear, fixup: fixupAlpha }
+	}
+};

--- a/src/lch/convertLabToLch.js
+++ b/src/lch/convertLabToLch.js
@@ -5,14 +5,10 @@ import normalizeHue from '../util/normalizeHue';
 		* https://drafts.csswg.org/css-color/#lab-to-lch
 		* https://drafts.csswg.org/css-color/#color-conversion-code
 */
-export default ({ l, a, b, alpha }) => {
+export default ({ l, a, b, alpha }, mode = 'lch') => {
 	let c = Math.sqrt(a * a + b * b);
-	let res = {
-		mode: 'lch',
-		l: l,
-		c: c
-	}
-	if (c) res.h = normalizeHue(Math.atan2(b, a) * 180 / Math.PI);
+	let res = { mode, l, c };
+	if (c) res.h = normalizeHue((Math.atan2(b, a) * 180) / Math.PI);
 	if (alpha !== undefined) res.alpha = alpha;
 	return res;
 };

--- a/src/lch/convertLchToLab.js
+++ b/src/lch/convertLchToLab.js
@@ -3,10 +3,10 @@
 		* https://drafts.csswg.org/css-color/#lch-to-lab
 		* https://drafts.csswg.org/css-color/#color-conversion-code
 */
-export default ({ l, c, h, alpha }) => {
+export default ({ l, c, h, alpha }, mode = 'lab') => {
 	let res = {
-		mode: 'lab',
-		l: l,
+		mode,
+		l,
 		a: c ? c * Math.cos((h / 180) * Math.PI) : 0,
 		b: c ? c * Math.sin((h / 180) * Math.PI) : 0
 	};

--- a/src/lch65/definition.js
+++ b/src/lch65/definition.js
@@ -1,0 +1,40 @@
+import convertLabToLch from '../lch/convertLabToLch';
+import convertLchToLab from '../lch/convertLchToLab';
+import convertLab65ToRgb from '../lab65/convertLab65ToRgb';
+import convertRgbToLab65 from '../lab65/convertRgbToLab65';
+import { fixupHueShorter } from '../fixup/hue';
+import { fixupAlpha } from '../fixup/alpha';
+import { interpolatorLinear } from '../interpolate/linear';
+import { differenceHueChroma } from '../difference';
+import { averageAngle } from '../average';
+
+export default {
+	mode: 'lch65',
+	alias: ['lch-d65'],
+	output: {
+		lab65: convertLchToLab,
+		rgb: c => convertLab65ToRgb(convertLchToLab(c, 'lab65'))
+	},
+	input: {
+		rgb: c => convertLabToLch(convertRgbToLab65(c), 'lch65'),
+		lab65: convertLabToLch
+	},
+	channels: ['l', 'c', 'h', 'alpha'],
+	ranges: {
+		l: [0, 100],
+		c: [0, 131.008],
+		h: [0, 360]
+	},
+	interpolate: {
+		h: { use: interpolatorLinear, fixup: fixupHueShorter },
+		c: interpolatorLinear,
+		l: interpolatorLinear,
+		alpha: { use: interpolatorLinear, fixup: fixupAlpha }
+	},
+	difference: {
+		h: differenceHueChroma
+	},
+	average: {
+		h: averageAngle
+	}
+};

--- a/src/lch65/definition.js
+++ b/src/lch65/definition.js
@@ -2,13 +2,10 @@ import convertLabToLch from '../lch/convertLabToLch';
 import convertLchToLab from '../lch/convertLchToLab';
 import convertLab65ToRgb from '../lab65/convertLab65ToRgb';
 import convertRgbToLab65 from '../lab65/convertRgbToLab65';
-import { fixupHueShorter } from '../fixup/hue';
-import { fixupAlpha } from '../fixup/alpha';
-import { interpolatorLinear } from '../interpolate/linear';
-import { differenceHueChroma } from '../difference';
-import { averageAngle } from '../average';
+import lch from '../lch/definition';
 
 export default {
+	...lch,
 	mode: 'lch65',
 	alias: ['lch-d65'],
 	output: {
@@ -19,22 +16,10 @@ export default {
 		rgb: c => convertLabToLch(convertRgbToLab65(c), 'lch65'),
 		lab65: convertLabToLch
 	},
-	channels: ['l', 'c', 'h', 'alpha'],
+	parsers: [],
 	ranges: {
 		l: [0, 100],
-		c: [0, 131.008],
+		c: [0, 133.807],
 		h: [0, 360]
-	},
-	interpolate: {
-		h: { use: interpolatorLinear, fixup: fixupHueShorter },
-		c: interpolatorLinear,
-		l: interpolatorLinear,
-		alpha: { use: interpolatorLinear, fixup: fixupAlpha }
-	},
-	difference: {
-		h: differenceHueChroma
-	},
-	average: {
-		h: averageAngle
 	}
 };

--- a/src/xyz65/constants.js
+++ b/src/xyz65/constants.js
@@ -2,3 +2,6 @@
 export const Xn = 0.95047;
 export const Yn = 1.0;
 export const Zn = 1.08883;
+
+export const k = Math.pow(29, 3) / Math.pow(3, 3);
+export const e = Math.pow(6, 3) / Math.pow(29, 3);

--- a/test/dlab.test.js
+++ b/test/dlab.test.js
@@ -1,0 +1,30 @@
+import tape from 'tape';
+import { dlab } from '../src/index';
+
+tape('dlab', t => {
+	t.deepEqual(
+		dlab('white'),
+		{ mode: 'dlab', l: 100.00000329450263, a: 0, b: 0 },
+		'white'
+	);
+
+	// Tests that achromatic RGB colors get a = b = 0
+	t.deepEqual(
+		dlab('#111'),
+		{ mode: 'dlab', l: 5.938148209426481, a: 0, b: 0 },
+		'#111'
+	);
+
+	t.deepEqual(dlab('black'), { mode: 'dlab', l: 0, a: 0, b: 0 }, 'black');
+	t.deepEqual(
+		dlab('red'),
+		{
+			mode: 'dlab',
+			l: 57.292786940734544,
+			a: 39.49865108060835,
+			b: 30.51816478216608
+		},
+		'red'
+	);
+	t.end();
+});

--- a/test/dlch.test.js
+++ b/test/dlch.test.js
@@ -1,0 +1,27 @@
+import tape from 'tape';
+import { dlch } from '../src/index';
+
+tape('dlch', t => {
+	t.deepEqual(
+		dlch('white'),
+		{ mode: 'dlch', l: 100.00000329450263, c: 0 },
+		'white'
+	);
+	t.deepEqual(
+		dlch('#111'),
+		{ mode: 'dlch', l: 5.938148209426481, c: 0 },
+		'#111'
+	);
+	t.deepEqual(dlch('black'), { mode: 'dlch', l: 0, c: 0 }, 'black');
+	t.deepEqual(
+		dlch('red'),
+		{
+			mode: 'dlch',
+			l: 57.292786940734544,
+			c: 49.91494584650057,
+			h: 37.691043152153014
+		},
+		'red'
+	);
+	t.end();
+});

--- a/test/lab65.test.js
+++ b/test/lab65.test.js
@@ -1,0 +1,30 @@
+import tape from 'tape';
+import { lab65 } from '../src/index';
+
+tape('lab65', t => {
+	t.deepEqual(
+		lab65('white'),
+		{ mode: 'lab65', l: 100.00000386666655, a: 0, b: 0 },
+		'white'
+	);
+
+	// Tests that achromatic RGB colors get a = b = 0 in CIELab D65
+	t.deepEqual(
+		lab65('#111'),
+		{ mode: 'lab65', l: 5.06332999976555, a: 0, b: 0 },
+		'#111'
+	);
+
+	t.deepEqual(lab65('black'), { mode: 'lab65', l: 0, a: 0, b: 0 }, 'black');
+	t.deepEqual(
+		lab65('red'),
+		{
+			mode: 'lab65',
+			l: 53.240794141307205,
+			a: 80.09245959641115,
+			b: 67.20319651585298
+		},
+		'red'
+	);
+	t.end();
+});

--- a/test/lch.test.js
+++ b/test/lch.test.js
@@ -1,0 +1,23 @@
+import tape from 'tape';
+import { lch } from '../src/index';
+
+tape('lch', t => {
+	t.deepEqual(lch('white'), { mode: 'lch', l: 100, c: 0 }, 'white');
+	t.deepEqual(
+		lch('#111'),
+		{ mode: 'lch', l: 5.063329493432597, c: 0 },
+		'#111'
+	);
+	t.deepEqual(lch('black'), { mode: 'lch', l: 0, c: 0 }, 'black');
+	t.deepEqual(
+		lch('red'),
+		{
+			mode: 'lch',
+			l: 54.29173376861782,
+			c: 106.83899941284552,
+			h: 40.85261277607024
+		},
+		'red'
+	);
+	t.end();
+});

--- a/test/lch65.test.js
+++ b/test/lch65.test.js
@@ -1,0 +1,27 @@
+import tape from 'tape';
+import { lch65 } from '../src/index';
+
+tape('lch65', t => {
+	t.deepEqual(
+		lch65('white'),
+		{ mode: 'lch65', l: 100.00000386666655, c: 0 },
+		'white'
+	);
+	t.deepEqual(
+		lch65('#111'),
+		{ mode: 'lch65', l: 5.06332999976555, c: 0 },
+		'#111'
+	);
+	t.deepEqual(lch65('black'), { mode: 'lch65', l: 0, c: 0 }, 'black');
+	t.deepEqual(
+		lch65('red'),
+		{
+			mode: 'lch65',
+			l: 53.240794141307205,
+			c: 104.55176567686988,
+			h: 39.99901061253291
+		},
+		'red'
+	);
+	t.end();
+});

--- a/tools/ranges.js
+++ b/tools/ranges.js
@@ -31,4 +31,4 @@ let ranges = (mode, step = 0.01) => {
 	return res;
 };
 
-console.log(ranges('jch', 0.002));
+console.log(ranges('lch65', 0.0025));


### PR DESCRIPTION
* Adds CIELab with D65 illuminant as `lab65` (cartesian) and `lch65` (polar)
* Switches DIN99o color space to be derived from CIELab under D65 illuminant, as intented in the spec