### PR TITLE
mapTransferGamma: fix pow -> Math.pow

### DIFF
--- a/src/map.js
+++ b/src/map.js
@@ -54,7 +54,7 @@ const mapTransferGamma = (amplitude = 1, exponent = 1, offset = 0) => (
 	ch
 ) => {
 	if (ch !== 'alpha') {
-		return amplitude * pow(v, exponent) + offset;
+		return amplitude * Math.pow(v, exponent) + offset;
 	}
 	return v;
 };

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -4,6 +4,7 @@ import {
 	mapAlphaMultiply,
 	mapAlphaDivide,
 	mapTransferLinear,
+	mapTransferGamma,
 	formatHex,
 	formatHex8
 } from '../src/index';
@@ -17,8 +18,14 @@ tape('mapping alpha', t => {
 	t.end();
 });
 
-tape('transfer functions', t => {
+tape('linear transfer function', t => {
 	let brighten = mapper(mapTransferLinear(2));
 	t.equal(formatHex(brighten('#cc0033')), '#ff0066');
+	t.end();
+});
+
+tape('gamma transfer function', t => {
+	let brighten = mapper(mapTransferGamma(2.2));
+	t.equal(formatHex(brighten('#cc0033')), '#ff0070');
 	t.end();
 });


### PR DESCRIPTION
There's no such global function as `pow`, so  `mapTransferGamma` didn't work.