### PR TITLE
Replace `tape` with `node:test`/ `node:assert`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+## Development
+
+Tests are defined using the `node:test` and `node:assert` modules. Running the tests require Node 21 or newer:
+
+```bash
+npm run test
+```
+
+We use ESLint to lint JavaScript code. 
+
+
+```bash
+npm run lint
+```
+
+While Culori can be used from source in environments supporting ES Modules, we also use esbuild to build bundles in CommonJS, ESM, and UMD formats.
+
+```bash
+npm run build
+```
+
+## Documentation
+
+The documentation website [culorijs.org] is built with Eleventy out of the `www/` folder, and deployed on GitHub pages via the `gh-pages` branch.
+
+The following scripts are available:
+
+```bash
+npm run docs:start
+npm run docs:build
+npm run docs:deploy
+```

--- a/README.md
+++ b/README.md
@@ -16,4 +16,8 @@ The full documentation is published on [culorijs.org](https://culorijs.org). Som
 
 ## Contributing
 
-Contributions of any kind (feedback, ideas, bug fixes) are welcome. Please open a GitHub issue before starting work on anything that's not straightforward.
+Contributions of all kinds (feedback, ideas, bug fixes, documentation) are welcome. 
+
+Please open a GitHub issue/discussion before putting in any work that’s not straightforward.
+
+More in [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 	},
 	"scripts": {
 		"prepare": "git config core.hooksPath .git-hooks",
-		"test": "tape 'test/**/*.test.js' | tap-arc",
+		"test": "node --test 'test/**/*.test.js'",
 		"start": "npx esbuild --servedir=.",
 		"build": "node build.js",
 		"benchmark": "node benchmark/index.js",

--- a/package.json
+++ b/package.json
@@ -54,9 +54,7 @@
 		"eslint-plugin-import": "^2.29.1",
 		"gh-pages": "^6.1.1",
 		"prettier": "^3.2.4",
-		"pretty-quick": "^4.0.0",
-		"tap-arc": "^1.2.2",
-		"tape": "^5.7.3"
+		"pretty-quick": "^4.0.0"
 	},
 	"scripts": {
 		"prepare": "git config core.hooksPath .git-hooks",

--- a/test/a98.test.js
+++ b/test/a98.test.js
@@ -1,14 +1,15 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { a98, rgb, formatCss } from '../src/index.js';
 
-tape('a98', t => {
-	t.deepEqual(
+test('a98', t => {
+	assert.deepEqual(
 		a98('white'),
 		{ mode: 'a98', r: 0.9999999999999999, g: 1, b: 1.0000000000000002 },
 		'white'
 	);
-	t.deepEqual(a98('black'), { mode: 'a98', r: 0, g: 0, b: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(a98('black'), { mode: 'a98', r: 0, g: 0, b: 0 }, 'black');
+	assert.deepEqual(
 		a98('red'),
 		{
 			mode: 'a98',
@@ -18,42 +19,38 @@ tape('a98', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(a98-rgb)', t => {
-	t.deepEqual(a98('color(a98-rgb 1 0 0 / 0.25)'), {
+test('color(a98-rgb)', t => {
+	assert.deepEqual(a98('color(a98-rgb 1 0 0 / 0.25)'), {
 		r: 1,
 		g: 0,
 		b: 0,
 		alpha: 0.25,
 		mode: 'a98'
 	});
-	t.deepEqual(a98('color(a98-rgb 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(a98('color(a98-rgb 0% 50% 0.5 / 25%)'), {
 		r: 0,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'a98'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(a98-rgb 0% 50% 0.5 / 25%)'),
 		'color(a98-rgb 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(a98-rgb none 0.5 none)'), 'a98 to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(a98-rgb none 0.5 none)'), 'a98 to rgb is ok');
+	assert.deepEqual(
 		rgb('color(a98-rgb none 0.5 none)'),
 		rgb('color(a98-rgb 0 0.5 0')
 	);
-	t.ok(a98('rgb(none 100 20)'), 'rgb to a98 is ok');
-	t.deepEqual(a98('rgb(none 100 20)'), a98('rgb(0 100 20)'));
-	t.end();
+	assert.ok(a98('rgb(none 100 20)'), 'rgb to a98 is ok');
+	assert.deepEqual(a98('rgb(none 100 20)'), a98('rgb(0 100 20)'));
 });

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -1,7 +1,8 @@
 /*
 	Keep an eye on the API surface of the various bundles
  */
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 
 import * as full from '../src/index.js';
 import * as css from '../src/bootstrap/css.js';
@@ -474,22 +475,18 @@ const API_FN = [
 	'wcagLuminance'
 ];
 
-tape('culori', t => {
-	t.deepEqual(Object.keys(full).sort(), API_FULL.sort());
-	t.end();
+test('culori', t => {
+	assert.deepEqual(Object.keys(full).sort(), API_FULL.sort());
 });
 
-tape('culori/css', t => {
-	t.deepEqual(Object.keys(css).sort(), API_CSS.sort());
-	t.end();
+test('culori/css', t => {
+	assert.deepEqual(Object.keys(css).sort(), API_CSS.sort());
 });
 
-tape('culori/all', t => {
-	t.deepEqual(Object.keys(all).sort(), API_ALL.sort());
-	t.end();
+test('culori/all', t => {
+	assert.deepEqual(Object.keys(all).sort(), API_ALL.sort());
 });
 
-tape('culori/fn', t => {
-	t.deepEqual(Object.keys(fn).sort(), API_FN.sort());
-	t.end();
+test('culori/fn', t => {
+	assert.deepEqual(Object.keys(fn).sort(), API_FN.sort());
 });

--- a/test/average.test.js
+++ b/test/average.test.js
@@ -1,13 +1,12 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { average, averageAngle, formatHex } from '../src/index.js';
 
-tape('average', t => {
-	t.equal(formatHex(average(['#ff0000', '#0000ff'])), '#800080');
-	t.equal(formatHex(average(['#ff0000', '#0000ff'], 'lch')), '#f50086');
-	t.end();
+test('average', t => {
+	assert.equal(formatHex(average(['#ff0000', '#0000ff'])), '#800080');
+	assert.equal(formatHex(average(['#ff0000', '#0000ff'], 'lch')), '#f50086');
 });
 
-tape('averageAngle', t => {
-	t.equal(averageAngle([270, 0]), 315);
-	t.end();
+test('averageAngle', t => {
+	assert.equal(averageAngle([270, 0]), 315);
 });

--- a/test/blend.test.js
+++ b/test/blend.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { blend } from '../src/index.js';
 
-tape('blendNormal', function (test) {
-	test.deepEqual(blend(['white', 'rgba(0, 0, 0, 0.5)']), {
+test('blendNormal', t => {
+	assert.deepEqual(blend(['white', 'rgba(0, 0, 0, 0.5)']), {
 		mode: 'rgb',
 		r: 0.5,
 		g: 0.5,
@@ -10,7 +11,7 @@ tape('blendNormal', function (test) {
 		alpha: 1
 	});
 
-	test.deepEqual(
+	assert.deepEqual(
 		blend([
 			{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 0.5 },
 			{ mode: 'rgb', r: 0, g: 0, b: 1, alpha: 0.5 }
@@ -25,16 +26,14 @@ tape('blendNormal', function (test) {
 	);
 
 	// blend with transparent source
-	test.deepEqual(
+	assert.deepEqual(
 		blend([{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 0.5 }, 'transparent']),
 		{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 0.5 }
 	);
 
 	// blend with transparent backdrop
-	test.deepEqual(
+	assert.deepEqual(
 		blend(['transparent', { mode: 'rgb', r: 1, g: 0, b: 0, alpha: 0.5 }]),
 		{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 0.5 }
 	);
-
-	test.end();
 });

--- a/test/cat.test.js
+++ b/test/cat.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { xyz65, xyz50, rgb } from '../src/index.js';
 
 let colors = ['red', 'green', 'blue', 'white', 'black', 'magenta', 'tomato'];
@@ -22,16 +23,14 @@ let sameRGB = (a, b) => {
 	);
 };
 
-tape('rgb -> xyz50 = rgb -> xyz65 -> xyz50', t => {
+test('rgb -> xyz50 = rgb -> xyz65 -> xyz50', t => {
 	colors.forEach(c => {
-		t.ok(sameXYZ(xyz50(rgb(c)), xyz50(xyz65(rgb(c)))), c);
+		assert.ok(sameXYZ(xyz50(rgb(c)), xyz50(xyz65(rgb(c)))), c);
 	});
-	t.end();
 });
 
-tape('rgb -> xyz50 -> rgb = rgb -> xyz50 -> xyz65 -> rgb', t => {
+test('rgb -> xyz50 -> rgb = rgb -> xyz50 -> xyz65 -> rgb', t => {
 	colors.forEach(c => {
-		t.ok(sameRGB(rgb(xyz50(rgb(c))), rgb(xyz65(xyz50(rgb(c))))), c);
+		assert.ok(sameRGB(rgb(xyz50(rgb(c))), rgb(xyz65(xyz50(rgb(c))))), c);
 	});
-	t.end();
 });

--- a/test/clamp.test.js
+++ b/test/clamp.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	clampChroma,
 	displayable,
@@ -10,46 +11,43 @@ import {
 	lch
 } from '../src/index.js';
 
-tape('RGB', function (test) {
-	test.equal(displayable({ mode: 'rgb', r: 0, g: 0, b: 0 }), true);
-	test.equal(
+test('RGB', t => {
+	assert.equal(displayable({ mode: 'rgb', r: 0, g: 0, b: 0 }), true);
+	assert.equal(
 		displayable({ mode: 'rgb', r: 1, g: 1, b: 1, alpha: 0.5 }),
 		true
 	);
-	test.equal(
+	assert.equal(
 		displayable({ mode: 'rgb', r: 1.1, g: 1, b: 1, alpha: 0.5 }),
 		false
 	);
-	test.end();
 });
 
-tape('LCh', function (test) {
-	test.equal(displayable('lch(50% 0 0)'), true);
-	test.equal(displayable('lch(50% -100 0)'), true);
-	test.equal(displayable('lch(120% -100 0)'), false);
-	test.end();
+test('LCh', t => {
+	assert.equal(displayable('lch(50% 0 0)'), true);
+	assert.equal(displayable('lch(50% -100 0)'), true);
+	assert.equal(displayable('lch(120% -100 0)'), false);
 });
 
-tape('clampChroma (rgb)', function (test) {
-	test.deepEqual(clampChroma('red'), { mode: 'rgb', r: 1, g: 0, b: 0 });
-	test.deepEqual(clampChroma('rgb(300, 255, 255)'), {
+test('clampChroma (rgb)', t => {
+	assert.deepEqual(clampChroma('red'), { mode: 'rgb', r: 1, g: 0, b: 0 });
+	assert.deepEqual(clampChroma('rgb(300, 255, 255)'), {
 		mode: 'rgb',
 		r: 1,
 		g: 1,
 		b: 1
 	});
-	test.end();
 });
 
-tape('clampChroma (lch)', function (test) {
-	test.deepEqual(clampChroma('lch(50% 120 5)'), {
+test('clampChroma (lch)', t => {
+	assert.deepEqual(clampChroma('lch(50% 120 5)'), {
 		mode: 'lch',
 		l: 50,
 		c: 77.4609375,
 		h: 5
 	});
-	test.equal(displayable(clampChroma('lch(50% 120 5)')), true);
-	test.deepEqual(
+	assert.equal(displayable(clampChroma('lch(50% 120 5)')), true);
+	assert.deepEqual(
 		clampChroma({
 			mode: 'lch',
 			l: 0,
@@ -64,84 +62,88 @@ tape('clampChroma (lch)', function (test) {
 		},
 		'for l = 0, only c = 0 is in gamut'
 	);
-	test.end();
 });
 
-tape('Issue #129', function (test) {
+test('Issue #129', t => {
 	let color = {
 		mode: 'lch',
 		l: 44.01740616147086,
 		c: 58.743630227529145,
 		h: 180.30393476177233
 	};
-	test.equal(displayable(clampChroma(color)), true);
-	test.equal(
+	assert.equal(displayable(clampChroma(color)), true);
+	assert.equal(
 		displayable(clampChroma({ mode: 'oklch', l: 0.5, c: 0.161, h: 180 })),
 		true
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		clampChroma({ mode: 'oklch', l: 0.5, c: 0.16, h: 180 }, 'oklch'),
 		{ mode: 'oklch', l: 0.5, c: 0.090703125, h: 180 }
 	);
 
-	test.equal(
+	assert.equal(
 		formatCss(clampChroma('lch(80% 150 60)', 'lch', 'p3')),
 		'lch(80 60.040283203125 60)',
 		'with p3 gamut'
 	);
-	test.end();
 });
 
-tape('inGamut()', t => {
-	t.equal(
+test('inGamut()', t => {
+	assert.equal(
 		inGamut('rec2020')('color(rec2020 1 1 0)'),
 		true,
 		'rec2020 in rec2020 gamut'
 	);
-	t.equal(
+	assert.equal(
 		inGamut('p3')('color(rec2020 1 1 0)'),
 		false,
 		'rec2020 in p3 gamut'
 	);
-	t.equal(
+	assert.equal(
 		inGamut('rgb')('color(rec2020 1 1 0)'),
 		false,
 		'rec2020 in rgb gamut'
 	);
 
-	t.equal(
+	assert.equal(
 		inGamut('rec2020')('color(display-p3 1 1 0)'),
 		true,
 		'p3 in rec2020 gamut'
 	);
-	t.equal(inGamut('p3')('color(display-p3 1 1 0)'), true, 'p3 in p3 gamut');
-	t.equal(
+	assert.equal(
+		inGamut('p3')('color(display-p3 1 1 0)'),
+		true,
+		'p3 in p3 gamut'
+	);
+	assert.equal(
 		inGamut('rgb')('color(display-p3 1 1 0)'),
 		false,
 		'p3 in rgb gamut'
 	);
 
-	t.equal(inGamut('hsl')('color(srgb 1 1 0)'), true, 'in hsl gamut');
-	t.equal(inGamut('hsl')('color(srgb 1 1.1 0)'), false, 'out of hsl gamut');
-
-	t.end();
+	assert.equal(inGamut('hsl')('color(srgb 1 1 0)'), true, 'in hsl gamut');
+	assert.equal(
+		inGamut('hsl')('color(srgb 1 1.1 0)'),
+		false,
+		'out of hsl gamut'
+	);
 });
 
-tape('clampGamut()', t => {
+test('clampGamut()', t => {
 	const p3Color = 'color(display-p3 1 1 0)';
 
-	t.equal(
+	assert.equal(
 		formatCss(clampGamut('rgb')(p3Color)),
 		'color(display-p3 0.9999999999999999 0.9999999999999997 0.3308973181805899)',
 		'p3 color to rgb'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(clampGamut('p3')(p3Color)),
 		'color(display-p3 1 1 0)',
 		'p3 color to p3'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(clampGamut('rec2020')(p3Color)),
 		'color(display-p3 1 1 0)',
 		'p3 color to rec2020'
@@ -150,32 +152,30 @@ tape('clampGamut()', t => {
 	const crimson = 'color(display-p3 0.8 0.1 0.3)';
 	const toRgb = clampGamut('rgb');
 
-	t.equal(
+	assert.equal(
 		formatCss(toRgb(crimson)),
 		'color(display-p3 0.8015640173988641 0.16985582666875737 0.30217671004779834)',
 		'api docs example'
 	);
-
-	t.end();
 });
 
-tape('toGamut()', t => {
-	t.equal(
+test('toGamut()', t => {
+	assert.equal(
 		formatCss(toGamut('rgb')({ mode: 'oklch', l: 1.5, c: 0.2, h: 180 })),
 		'color(srgb 1 1 1)',
 		'white'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(toGamut('rgb')({ mode: 'oklch', l: -1.5, c: 0.2, h: 180 })),
 		'color(srgb 0 0 0)',
 		'black'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(toGamut('rgb')('color(--lch-d65 100 0 180)')),
 		'color(srgb 0.9999999999999968 1.0000000000000016 0.9999999999999986)',
 		'chroma = 0'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(toGamut('p3')('lch(80% 150 60)')),
 		'color(display-p3 0.9999999999999994 0.6969234154991887 0.5084794582132421)',
 		'api docs example'
@@ -183,22 +183,20 @@ tape('toGamut()', t => {
 
 	const likeClampChroma = toGamut('rgb', 'lch', null);
 
-	t.deepEqual(lch(likeClampChroma('lch(50% 120 5)')), {
+	assert.deepEqual(lch(likeClampChroma('lch(50% 120 5)')), {
 		mode: 'lch',
 		l: 50.00519612994975,
 		c: 77.47625128342412,
 		h: 5.006331789592595
 	});
-
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(displayable('rgb(none none none)'), 'displayable');
+test('missing components', t => {
+	assert.ok(displayable('rgb(none none none)'), 'displayable');
 
-	t.ok(inGamut('p3')('color(display-p3 none none none)'), 'inGamut');
+	assert.ok(inGamut('p3')('color(display-p3 none none none)'), 'inGamut');
 
-	t.deepEqual(
+	assert.deepEqual(
 		clampRgb('rgb(none 300 none)'),
 		{
 			mode: 'rgb',
@@ -209,7 +207,7 @@ tape('missing components', t => {
 		'clampRgb'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		clampGamut('p3')('color(display-p3 none 3 none)'),
 		{
 			mode: 'p3',
@@ -220,7 +218,7 @@ tape('missing components', t => {
 		'clampGamut'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		clampChroma({
 			mode: 'lch',
 			l: 120
@@ -233,7 +231,7 @@ tape('missing components', t => {
 		'clampChroma, lch color (no conversion)'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		clampChroma('color(srgb 1.1 none none)'),
 		{
 			mode: 'rgb',
@@ -244,7 +242,7 @@ tape('missing components', t => {
 		'clampChroma, rgb color'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		toGamut()({
 			mode: 'lch',
 			l: 120
@@ -253,7 +251,7 @@ tape('missing components', t => {
 		'toGamut(), oklch color (no conversion)'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		toGamut()('color(srgb 1.1 none none)'),
 		{
 			mode: 'rgb',
@@ -263,6 +261,4 @@ tape('missing components', t => {
 		},
 		'toGamut(), rgb color'
 	);
-
-	t.end();
 });

--- a/test/color-syntax.test.js
+++ b/test/color-syntax.test.js
@@ -1,7 +1,8 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { parse } from '../src/index.js';
 
-tape('fewer values than channels', t => {
+test('fewer values than channels', t => {
 	const tests = [
 		'color(srgb)',
 		'color(srgb )',
@@ -12,41 +13,37 @@ tape('fewer values than channels', t => {
 		'color( srgb 25% .5 / 0.2)'
 	];
 	tests.forEach(test => {
-		t.equal(parse(test), undefined, test);
+		assert.equal(parse(test), undefined, test);
 	});
-	t.end();
 });
 
-tape('more values than channels', t => {
+test('more values than channels', t => {
 	const tests = [
 		'color(srgb 25% .5 75% 0.33 0.66)',
 		'color(srgb 25% .5 75% 0.33 0.66 / 70% )',
 		'color(srgb 25% .5 75% 0.33 / 0.7)'
 	];
 	tests.forEach(test => {
-		t.equal(parse(test), undefined, test);
+		assert.equal(parse(test), undefined, test);
 	});
-	t.end();
 });
 
-tape('hue components', t => {
+test('hue components', t => {
 	const tests = ['color(srgb 0.5 0.5 0deg)'];
 	tests.forEach(test => {
-		t.equal(parse(test), undefined, test);
+		assert.equal(parse(test), undefined, test);
 	});
-	t.end();
 });
 
-tape('clamp alpha', t => {
-	t.deepEqual(
+test('clamp alpha', t => {
+	assert.deepEqual(
 		parse('color(srgb 1.5 -0.4 0.2 / -0.5)'),
 		{ mode: 'rgb', r: 1.5, g: -0.4, b: 0.2, alpha: 0 },
 		'clamp alpha < 0'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		parse('color(srgb 1.5 -0.4 0.2 / 1.5)'),
 		{ mode: 'rgb', r: 1.5, g: -0.4, b: 0.2, alpha: 1 },
 		'clamp alpha > 1'
 	);
-	t.end();
 });

--- a/test/css.test.js
+++ b/test/css.test.js
@@ -1,26 +1,23 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { formatRgb, formatHex, rgb } from '../src/index.js';
 
-tape('formatRgb', function (test) {
-	test.deepEqual(
+test('formatRgb', t => {
+	assert.deepEqual(
 		formatRgb(rgb('rgb(200, 300, 100)')),
 		'rgb(200, 255, 100)',
 		'rgb'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		formatRgb(rgb('rgba(200, 300, 100, 0.1)')),
 		'rgba(200, 255, 100, 0.1)',
 		'rgb'
 	);
-
-	test.end();
 });
 
-tape('formatHex', function (test) {
-	test.deepEqual(formatHex(rgb('#c0c2ff')), '#c0c2ff', '#c0c2ff');
+test('formatHex', t => {
+	assert.deepEqual(formatHex(rgb('#c0c2ff')), '#c0c2ff', '#c0c2ff');
 
-	test.deepEqual(formatHex(rgb('#00c2ff')), '#00c2ff', '#00c2ff');
-
-	test.end();
+	assert.deepEqual(formatHex(rgb('#00c2ff')), '#00c2ff', '#00c2ff');
 });

--- a/test/cubehelix.test.js
+++ b/test/cubehelix.test.js
@@ -1,39 +1,37 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { cubehelix, formatCss, rgb } from '../src/index.js';
 
-tape('color(--cubehelix)', t => {
-	t.deepEqual(cubehelix('color(--cubehelix 30 0.5 1 / 0.25)'), {
+test('color(--cubehelix)', t => {
+	assert.deepEqual(cubehelix('color(--cubehelix 30 0.5 1 / 0.25)'), {
 		h: 30,
 		s: 0.5,
 		l: 1,
 		alpha: 0.25,
 		mode: 'cubehelix'
 	});
-	t.deepEqual(cubehelix('color(--cubehelix 0 50% 0.5 / 25%)'), {
+	assert.deepEqual(cubehelix('color(--cubehelix 0 50% 0.5 / 25%)'), {
 		h: 0,
 		s: 0.5,
 		l: 0.5,
 		alpha: 0.25,
 		mode: 'cubehelix'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--cubehelix 0 50% 0.5 / 25%)'),
 		'color(--cubehelix 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--cubehelix none 0.5 none)'));
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--cubehelix none 0.5 none)'));
+	assert.deepEqual(
 		rgb('color(--cubehelix none 0.5 none)'),
 		rgb('color(--cubehelix 0 0.5 0)')
 	);
-	t.ok(cubehelix('rgb(none 100 20)'));
-	t.deepEqual(cubehelix('rgb(none 100 20)'), cubehelix('rgb(0 100 20)'));
-	t.end();
+	assert.ok(cubehelix('rgb(none 100 20)'));
+	assert.deepEqual(cubehelix('rgb(none 100 20)'), cubehelix('rgb(0 100 20)'));
 });

--- a/test/deficiency.test.js
+++ b/test/deficiency.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	filterDeficiencyProt,
 	filterDeficiencyDeuter,
@@ -6,23 +7,20 @@ import {
 	formatHex
 } from '../src/index.js';
 
-tape('0 severity', t => {
-	t.equal(formatHex(filterDeficiencyProt(0)('red')), '#ff0000');
-	t.equal(formatHex(filterDeficiencyDeuter(0)('red')), '#ff0000');
-	t.equal(formatHex(filterDeficiencyTrit(0)('red')), '#ff0000');
-	t.end();
+test('0 severity', t => {
+	assert.equal(formatHex(filterDeficiencyProt(0)('red')), '#ff0000');
+	assert.equal(formatHex(filterDeficiencyDeuter(0)('red')), '#ff0000');
+	assert.equal(formatHex(filterDeficiencyTrit(0)('red')), '#ff0000');
 });
 
-tape('0.55 severity', t => {
-	t.equal(formatHex(filterDeficiencyProt(0.55)('blue')), '#0012ff');
-	t.equal(formatHex(filterDeficiencyDeuter(0.55)('blue')), '#000afa');
-	t.equal(formatHex(filterDeficiencyTrit(0.55)('blue')), '#000fae');
-	t.end();
+test('0.55 severity', t => {
+	assert.equal(formatHex(filterDeficiencyProt(0.55)('blue')), '#0012ff');
+	assert.equal(formatHex(filterDeficiencyDeuter(0.55)('blue')), '#000afa');
+	assert.equal(formatHex(filterDeficiencyTrit(0.55)('blue')), '#000fae');
 });
 
-tape('1 severity', t => {
-	t.equal(formatHex(filterDeficiencyProt(1)('green')), '#876500');
-	t.equal(formatHex(filterDeficiencyDeuter(1)('green')), '#6e5605');
-	t.equal(formatHex(filterDeficiencyTrit(1)('green')), '#007758');
-	t.end();
+test('1 severity', t => {
+	assert.equal(formatHex(filterDeficiencyProt(1)('green')), '#876500');
+	assert.equal(formatHex(filterDeficiencyDeuter(1)('green')), '#6e5605');
+	assert.equal(formatHex(filterDeficiencyTrit(1)('green')), '#007758');
 });

--- a/test/difference.test.js
+++ b/test/difference.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	differenceEuclidean,
 	differenceCie76,
@@ -14,10 +15,10 @@ import {
 	hsl
 } from '../src/index.js';
 
-tape('euclidean distance in RGB', function (test) {
+test('euclidean distance in RGB', t => {
 	let delta = differenceEuclidean();
 
-	test.equal(
+	assert.equal(
 		delta(
 			rgb({ r: 1, g: 0, b: 0, alpha: 0.5 }),
 			rgb({ r: 0, g: 1, b: 0, alpha: 0.75 })
@@ -25,57 +26,49 @@ tape('euclidean distance in RGB', function (test) {
 		1.4142135623730951
 	);
 
-	test.equal(delta('red', 'red'), 0);
-
-	test.end();
+	assert.equal(delta('red', 'red'), 0);
 });
 
-tape('euclidean distance in HSL', function (test) {
+test('euclidean distance in HSL', t => {
 	let delta = differenceEuclidean('hsl');
 
-	test.equal(
+	assert.equal(
 		delta(hsl({ h: 0, s: 1, l: 1 }), hsl({ h: 180, s: 1, l: 1 })),
 		2
 	);
 
-	test.equal(
+	assert.equal(
 		delta(hsl({ h: 0, s: 1, l: 1 }), hsl({ h: 360, s: 1, l: 1 })),
 		2.4492935982947064e-16
 	);
 
-	test.equal(
+	assert.equal(
 		delta(hsl({ h: 60, s: 1, l: 1 }), hsl({ h: -540, s: 1, l: 1 })),
 		1.732050807568877
 	);
-
-	test.end();
 });
 
-tape('cie76 difference', function (test) {
-	test.equal(
+test('cie76 difference', t => {
+	assert.equal(
 		differenceCie76()(
 			lab65({ l: 1, a: 0, b: 0, alpha: 0.5 }),
 			lab65({ l: 0, a: 1, b: 0, alpha: 0.75 })
 		),
 		1.4142135623730951
 	);
-
-	test.end();
 });
 
-tape('cie94 difference', function (test) {
-	test.equal(
+test('cie94 difference', t => {
+	assert.equal(
 		differenceCie94()(
 			lab65({ l: 1, a: 0, b: 0, alpha: 0.5 }),
 			lab65({ l: 0, a: 1, b: 0, alpha: 0.75 })
 		),
 		1.4142135623730951
 	);
-
-	test.end();
 });
 
-tape('ciede2000 difference', function (test) {
+test('ciede2000 difference', t => {
 	let approx = round(4);
 
 	// Test data from: http://www2.ece.rochester.edu/~gsharma/ciede2000/
@@ -118,7 +111,7 @@ tape('ciede2000 difference', function (test) {
 
 	for (var i = 0; i < testdata.length; i++) {
 		let line = testdata[i];
-		test.equal(
+		assert.equal(
 			approx(
 				differenceCiede2000()(
 					lab65({ l: +line[0], a: +line[1], b: +line[2] }),
@@ -129,7 +122,7 @@ tape('ciede2000 difference', function (test) {
 		);
 
 		// also test for symmetry
-		test.equal(
+		assert.equal(
 			approx(
 				differenceCiede2000()(
 					lab65({ l: +line[3], a: +line[4], b: +line[5] }),
@@ -139,12 +132,10 @@ tape('ciede2000 difference', function (test) {
 			+line[6]
 		);
 	}
-
-	test.end();
 });
 
-tape('differenceCmc', function (test) {
-	test.equal(
+test('differenceCmc', t => {
+	assert.equal(
 		differenceCmc()(
 			lab65({ l: 1, a: 0, b: 0, alpha: 0.5 }),
 			lab65({ l: 0, a: 1, b: 0, alpha: 0.75 })
@@ -152,44 +143,37 @@ tape('differenceCmc', function (test) {
 		2.507265255284643
 	);
 
-	test.equal(
+	assert.equal(
 		differenceCmc()('rgb(55, 60, 48)', 'rgb(55, 65, 53)'),
 		3.590406912120119
 	);
 
-	test.equal(
+	assert.equal(
 		differenceCmc(2, 1)('rgb(55, 60, 48)', 'rgb(55, 65, 53)'),
 		2.82061249589761
 	);
 
-	test.equal(
+	assert.equal(
 		differenceCmc()('lab(50% 40 20)', 'lab(60% 20 100)'),
 		53.10947821085943
 	);
-
-	test.end();
 });
 
-tape('differenceKotsarenkoRamos', function (test) {
-	test.equal(
+test('differenceKotsarenkoRamos', t => {
+	assert.equal(
 		differenceKotsarenkoRamos()('white', 'black'),
 		0.7108445752103619
 	);
-
-	test.end();
 });
 
-tape('difference in LCh space', t => {
-	t.equal(differenceEuclidean('lch')('red', 'green'), 130.3598834181675);
-	t.end();
+test('difference in LCh space', t => {
+	assert.equal(differenceEuclidean('lch')('red', 'green'), 130.3598834181675);
 });
 
-tape('differenceHyab', t => {
-	t.equal(differenceHyab()('red', 'green'), 139.92805737622862);
-	t.end();
+test('differenceHyab', t => {
+	assert.equal(differenceHyab()('red', 'green'), 139.92805737622862);
 });
 
-tape('differenceItp', t => {
-	t.equal(differenceItp()('red', 'green'), 238.28868759957626);
-	t.end();
+test('differenceItp', t => {
+	assert.equal(differenceItp()('red', 'green'), 238.28868759957626);
 });

--- a/test/dlab.test.js
+++ b/test/dlab.test.js
@@ -1,18 +1,27 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { dlab, rgb, formatCss } from '../src/index.js';
 
-tape('dlab', t => {
-	t.deepEqual(dlab('white'), { mode: 'dlab', l: 100, a: 0, b: 0 }, 'white');
+test('dlab', t => {
+	assert.deepEqual(
+		dlab('white'),
+		{ mode: 'dlab', l: 100, a: 0, b: 0 },
+		'white'
+	);
 
 	// Tests that achromatic RGB colors get a = b = 0
-	t.deepEqual(
+	assert.deepEqual(
 		dlab('#111'),
 		{ mode: 'dlab', l: 5.938147621379976, a: 0, b: 0 },
 		'#111'
 	);
 
-	t.deepEqual(dlab('black'), { mode: 'dlab', l: 0, a: 0, b: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(
+		dlab('black'),
+		{ mode: 'dlab', l: 0, a: 0, b: 0 },
+		'black'
+	);
+	assert.deepEqual(
 		dlab('red'),
 		{
 			mode: 'dlab',
@@ -22,42 +31,38 @@ tape('dlab', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(--din99o-lab)', t => {
-	t.deepEqual(dlab('color(--din99o-lab 30 0.5 1 / 0.25)'), {
+test('color(--din99o-lab)', t => {
+	assert.deepEqual(dlab('color(--din99o-lab 30 0.5 1 / 0.25)'), {
 		l: 30,
 		a: 0.5,
 		b: 1,
 		alpha: 0.25,
 		mode: 'dlab'
 	});
-	t.deepEqual(dlab('color(--din99o-lab 0 50% 0.5 / 25%)'), {
+	assert.deepEqual(dlab('color(--din99o-lab 0 50% 0.5 / 25%)'), {
 		l: 0,
 		a: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'dlab'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--din99o-lab 0 50% 0.5 / 25%)'),
 		'color(--din99o-lab 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--din99o-lab none 0.5 none)'), 'dlab to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--din99o-lab none 0.5 none)'), 'dlab to rgb is ok');
+	assert.deepEqual(
 		rgb('color(--din99o-lab none 0.5 none)'),
 		rgb('color(--din99o-lab 0 0.5 0)')
 	);
-	t.ok(dlab('rgb(none 100 20)'), 'rgb to dlab is ok');
-	t.deepEqual(dlab('rgb(none 100 20)'), dlab('rgb(0 100 20)'));
-	t.end();
+	assert.ok(dlab('rgb(none 100 20)'), 'rgb to dlab is ok');
+	assert.deepEqual(dlab('rgb(none 100 20)'), dlab('rgb(0 100 20)'));
 });

--- a/test/dlch.test.js
+++ b/test/dlch.test.js
@@ -1,15 +1,16 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { dlch, rgb, formatCss } from '../src/index.js';
 
-tape('dlch', t => {
-	t.deepEqual(dlch('white'), { mode: 'dlch', l: 100, c: 0 }, 'white');
-	t.deepEqual(
+test('dlch', t => {
+	assert.deepEqual(dlch('white'), { mode: 'dlch', l: 100, c: 0 }, 'white');
+	assert.deepEqual(
 		dlch('#111'),
 		{ mode: 'dlch', l: 5.938147621379976, c: 0 },
 		'#111'
 	);
-	t.deepEqual(dlch('black'), { mode: 'dlch', l: 0, c: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(dlch('black'), { mode: 'dlch', l: 0, c: 0 }, 'black');
+	assert.deepEqual(
 		dlch('red'),
 		{
 			mode: 'dlch',
@@ -19,42 +20,38 @@ tape('dlch', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(--din99o-lch)', t => {
-	t.deepEqual(dlch('color(--din99o-lch 30 0.5 1 / 0.25)'), {
+test('color(--din99o-lch)', t => {
+	assert.deepEqual(dlch('color(--din99o-lch 30 0.5 1 / 0.25)'), {
 		l: 30,
 		c: 0.5,
 		h: 1,
 		alpha: 0.25,
 		mode: 'dlch'
 	});
-	t.deepEqual(dlch('color(--din99o-lch 0 50% 0.5 / 25%)'), {
+	assert.deepEqual(dlch('color(--din99o-lch 0 50% 0.5 / 25%)'), {
 		l: 0,
 		c: 0.5,
 		h: 0.5,
 		alpha: 0.25,
 		mode: 'dlch'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--din99o-lch 0 50% 0.5 / 25%)'),
 		'color(--din99o-lch 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--din99o-lch none 0.5 none)'), 'dlch to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--din99o-lch none 0.5 none)'), 'dlch to rgb is ok');
+	assert.deepEqual(
 		rgb('color(--din99o-lch none 0.5 none)'),
 		rgb('color(--din99o-lch 0% 0.5 0)')
 	);
-	t.ok(dlch('rgb(none 100 20)'), 'rgb to dlch is ok');
-	t.deepEqual(dlch('rgb(none 100 20)'), dlch('rgb(0 100 20)'));
-	t.end();
+	assert.ok(dlch('rgb(none 100 20)'), 'rgb to dlch is ok');
+	assert.deepEqual(dlch('rgb(none 100 20)'), dlch('rgb(0 100 20)'));
 });

--- a/test/easing.test.js
+++ b/test/easing.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 
 import midpoint from '../src/easing/midpoint.js';
 import {
@@ -8,42 +9,37 @@ import {
 import smootherstep from '../src/easing/smootherstep.js';
 import samples from '../src/samples.js';
 
-tape('easingMidpoint', t => {
+test('easingMidpoint', t => {
 	let noop = midpoint(0.5);
 	let curve = midpoint(0.2);
 
-	t.equal(noop(0.1), 0.1);
-	t.equal(noop(0.4), 0.4);
-	t.equal(noop(0.5), 0.5);
-	t.equal(noop(0.7), 0.7);
-	t.equal(noop(1), 1);
+	assert.equal(noop(0.1), 0.1);
+	assert.equal(noop(0.4), 0.4);
+	assert.equal(noop(0.5), 0.5);
+	assert.equal(noop(0.7), 0.7);
+	assert.equal(noop(1), 1);
 
-	t.equal(curve(0), 0);
-	t.equal(curve(1), 1);
-
-	t.end();
+	assert.equal(curve(0), 0);
+	assert.equal(curve(1), 1);
 });
 
-tape('easingSmoothstep', t => {
-	t.equal(easingSmoothstep(0), 0);
-	t.equal(easingSmoothstep(1), 1);
-	t.equal(easingSmoothstep(0.5), 0.5);
-	t.end();
+test('easingSmoothstep', t => {
+	assert.equal(easingSmoothstep(0), 0);
+	assert.equal(easingSmoothstep(1), 1);
+	assert.equal(easingSmoothstep(0.5), 0.5);
 });
 
-tape('easingSmoothstepInverse', t => {
+test('easingSmoothstepInverse', t => {
 	samples(5).forEach(x => {
-		t.ok(
+		assert.ok(
 			Math.abs(easingSmoothstepInverse(easingSmoothstep(x)) - x) < 1e-15,
 			`roundtrip: ${x}`
 		);
 	});
-	t.end();
 });
 
-tape('easingSmootherstep', t => {
-	t.equal(smootherstep(0), 0);
-	t.equal(smootherstep(1), 1);
-	t.equal(smootherstep(0.5), 0.5);
-	t.end();
+test('easingSmootherstep', t => {
+	assert.equal(smootherstep(0), 0);
+	assert.equal(smootherstep(1), 1);
+	assert.equal(smootherstep(0.5), 0.5);
 });

--- a/test/filter.test.js
+++ b/test/filter.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	filterBrightness,
 	filterContrast,
@@ -10,64 +11,69 @@ import {
 	filterHueRotate
 } from '../src/index.js';
 
-tape('filterBrightness', t => {
-	t.deepEqual(
+test('filterBrightness', t => {
+	assert.deepEqual(
 		filterBrightness(1)('hsl(60 100% 50% / 25%)'),
 		{ mode: 'hsl', h: 60, s: 1, l: 0.5, alpha: 0.25 },
 		'unchanged in the original color space'
 	);
-	t.equal(
+	assert.equal(
 		formatHex(filterBrightness(2)('#003366')),
 		'#0066cc',
 		'brightens the color'
 	);
-	t.end();
 });
 
-tape('filterContrast', t => {
-	t.equal(
+test('filterContrast', t => {
+	assert.equal(
 		formatHex(filterContrast(2)('#003366')),
 		'#00004d',
 		'Increases the contrast'
 	);
-	t.end();
 });
 
-tape('filterSepia', t => {
-	t.equal(formatHex(filterSepia(0)('red')), '#ff0000', 'unchanged');
-	t.equal(formatHex(filterSepia(1)('red')), '#645945', 'fully sepia');
-	t.end();
+test('filterSepia', t => {
+	assert.equal(formatHex(filterSepia(0)('red')), '#ff0000', 'unchanged');
+	assert.equal(formatHex(filterSepia(1)('red')), '#645945', 'fully sepia');
 });
 
-tape('filterSaturate', t => {
-	t.equal(
+test('filterSaturate', t => {
+	assert.equal(
 		formatHex(filterSaturate(0)('#cc0033')),
 		'#2f2f2f',
 		'fully desaturated'
 	);
-	t.equal(formatHex(filterSaturate(1)('#cc0033')), '#cc0033', 'unchanged');
-	t.equal(
+	assert.equal(
+		formatHex(filterSaturate(1)('#cc0033')),
+		'#cc0033',
+		'unchanged'
+	);
+	assert.equal(
 		formatHex(filterSaturate(2)('#cc0033')),
 		'#ff0037',
 		'oversaturated'
 	);
-	t.end();
 });
 
-tape('filterGrayscale', t => {
-	t.equal(formatHex(filterGrayscale(0)('red')), '#ff0000', 'unchanged');
-	t.equal(formatHex(filterGrayscale(1)('red')), '#363636', 'fully grayscale');
-	t.end();
+test('filterGrayscale', t => {
+	assert.equal(formatHex(filterGrayscale(0)('red')), '#ff0000', 'unchanged');
+	assert.equal(
+		formatHex(filterGrayscale(1)('red')),
+		'#363636',
+		'fully grayscale'
+	);
 });
 
-tape('filterInvert', t => {
-	t.equal(formatHex(filterInvert(0)('red')), '#ff0000', 'unchanged');
-	t.equal(formatHex(filterInvert(0.5)('red')), '#808080', 'gray');
-	t.equal(formatHex(filterInvert(1)('red')), '#00ffff', 'fully inverted');
-	t.end();
+test('filterInvert', t => {
+	assert.equal(formatHex(filterInvert(0)('red')), '#ff0000', 'unchanged');
+	assert.equal(formatHex(filterInvert(0.5)('red')), '#808080', 'gray');
+	assert.equal(
+		formatHex(filterInvert(1)('red')),
+		'#00ffff',
+		'fully inverted'
+	);
 });
 
-tape('filterHueRotate', t => {
-	t.equal(formatHex(filterHueRotate(60)('red')), '#6c3b00');
-	t.end();
+test('filterHueRotate', t => {
+	assert.equal(formatHex(filterHueRotate(60)('red')), '#6c3b00');
 });

--- a/test/fixupAlpha.test.js
+++ b/test/fixupAlpha.test.js
@@ -1,16 +1,15 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { fixupAlpha } from '../src/index.js';
 
-tape('fixupAlpha: some defined', t => {
-	t.deepEqual(fixupAlpha([undefined, 0, undefined]), [1, 0, 1]);
-	t.end();
+test('fixupAlpha: some defined', t => {
+	assert.deepEqual(fixupAlpha([undefined, 0, undefined]), [1, 0, 1]);
 });
 
-tape('fixupAlpha: all undefined', t => {
-	t.deepEqual(fixupAlpha([undefined, undefined, undefined]), [
+test('fixupAlpha: all undefined', t => {
+	assert.deepEqual(fixupAlpha([undefined, undefined, undefined]), [
 		undefined,
 		undefined,
 		undefined
 	]);
-	t.end();
 });

--- a/test/fixupHue.test.js
+++ b/test/fixupHue.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	fixupHueShorter,
 	fixupHueLonger,
@@ -6,32 +7,33 @@ import {
 	fixupHueDecreasing
 } from '../src/index.js';
 
-tape('fixupHueShorter', t => {
-	t.deepEqual(fixupHueShorter([0, 340, 30, 0, 170]), [0, -20, 30, 0, 170]);
-	t.deepEqual(fixupHueShorter([-250, -8]), [110, -8]);
-	t.end();
+test('fixupHueShorter', t => {
+	assert.deepEqual(
+		fixupHueShorter([0, 340, 30, 0, 170]),
+		[0, -20, 30, 0, 170]
+	);
+	assert.deepEqual(fixupHueShorter([-250, -8]), [110, -8]);
 });
 
-tape('fixupHueLonger', t => {
-	t.deepEqual(fixupHueLonger([0, 340, 30, 0, 170]), [0, 340, 30, 360, 170]);
+test('fixupHueLonger', t => {
+	assert.deepEqual(
+		fixupHueLonger([0, 340, 30, 0, 170]),
+		[0, 340, 30, 360, 170]
+	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		fixupHueLonger([0, 179, 179, 360]),
 		[0, -181, -181, 0],
 		'equal consecutive values'
 	);
-
-	t.end();
 });
 
-tape('fixupHueIncreasing', t => {
+test('fixupHueIncreasing', t => {
 	let hues = [0, 340, 30, 0, 170];
-	t.deepEqual(fixupHueIncreasing(hues), [0, 340, 390, 720, 890]);
-	t.end();
+	assert.deepEqual(fixupHueIncreasing(hues), [0, 340, 390, 720, 890]);
 });
 
-tape('fixupHueDecreasing', t => {
+test('fixupHueDecreasing', t => {
 	let hues = [0, 340, 30, 0, 170];
-	t.deepEqual(fixupHueDecreasing(hues), [0, -20, -330, -360, -550]);
-	t.end();
+	assert.deepEqual(fixupHueDecreasing(hues), [0, -20, -330, -360, -550]);
 });

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	formatHex,
 	formatHex8,
@@ -7,29 +8,25 @@ import {
 	rgb
 } from '../src/index.js';
 
-tape('formatHex', function (test) {
-	test.equal(formatHex('tomato'), '#ff6347');
-	test.end();
+test('formatHex', t => {
+	assert.equal(formatHex('tomato'), '#ff6347');
 });
 
-tape('formatHex8', t => {
-	t.equal(
+test('formatHex8', t => {
+	assert.equal(
 		formatHex8({ mode: 'rgb', r: 1, g: 1, b: 1, alpha: 0 }),
 		'#ffffff00'
 	);
-	t.end();
 });
 
-tape('formatRgb', function (test) {
-	test.equal(formatRgb(rgb('#f0f0f0f0')), 'rgba(240, 240, 240, 0.94)');
-	test.equal(formatRgb('#f0f0f0f0'), 'rgba(240, 240, 240, 0.94)');
-
-	test.end();
+test('formatRgb', t => {
+	assert.equal(formatRgb(rgb('#f0f0f0f0')), 'rgba(240, 240, 240, 0.94)');
+	assert.equal(formatRgb('#f0f0f0f0'), 'rgba(240, 240, 240, 0.94)');
 });
 
-tape('formatHsl', function (test) {
-	test.equal(formatHsl('red'), 'hsl(0, 100%, 50%)');
-	test.equal(
+test('formatHsl', t => {
+	assert.equal(formatHsl('red'), 'hsl(0, 100%, 50%)');
+	assert.equal(
 		formatHsl({
 			mode: 'hsl',
 			h: 30.21,
@@ -39,9 +36,8 @@ tape('formatHsl', function (test) {
 		}),
 		'hsla(30.21, 23.61%, 48.32%, 0)'
 	);
-	test.equal(
+	assert.equal(
 		formatHsl({ mode: 'hsl', h: 405, s: 1.2, l: -1 }),
 		'hsl(405, 100%, 0%)'
 	);
-	test.end();
 });

--- a/test/hsi.test.js
+++ b/test/hsi.test.js
@@ -1,128 +1,125 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { hsi, rgb, formatCss } from '../src/index.js';
 
-tape('rgb() converts from HSI to RGB', function (test) {
-	test.deepEqual(
+test('rgb() converts from HSI to RGB', t => {
+	assert.deepEqual(
 		rgb(hsi({ h: 0, s: 0, i: 0 })),
 		{ r: 0, g: 0, b: 0, mode: 'rgb' },
 		'lightness 0 should yield black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsi({ h: 60, s: 0.25, i: 0 })),
 		{ r: 0, g: 0, b: 0, mode: 'rgb' },
 		'...regardless of hue and saturation'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsi({ h: 0, s: 0, i: 0.5 })),
 		{ r: 0.5, g: 0.5, b: 0.5, mode: 'rgb' },
 		'saturation 0 should yield gray'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsi({ h: 60, s: 0, i: 0.25 })),
 		{ r: 0.25, g: 0.25, b: 0.25, mode: 'rgb' },
 		'...regardless of the hue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsi({ h: 100, s: 0, i: 0.5 })),
 		{ r: 0.5, g: 0.5, b: 0.5, mode: 'rgb' },
 		'...or the lightness'
 	);
-
-	test.end();
 });
 
-tape('hsi() converts RGB to HSI', function (test) {
-	test.deepEqual(
+test('hsi() converts RGB to HSI', t => {
+	assert.deepEqual(
 		hsi(rgb({ r: 0, g: 0, b: 0 })),
 		{ s: 0, i: 0, mode: 'hsi' },
 		'black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 0.25, g: 0.25, b: 0.25 })),
 		{ s: 0, i: 0.25, mode: 'hsi' },
 		'R = G = B yields undefined hue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 0.6, g: 0.6, b: 0.6 })),
 		{ s: 0, i: 0.6, mode: 'hsi' },
 		'R = G = B yields zero saturation'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 1, g: 0, b: 0 })),
 		{ h: 0, s: 1, i: 0.3333333333333333, mode: 'hsi' },
 		'red'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 1, g: 1, b: 0 })),
 		{ h: 60, s: 1, i: 0.6666666666666666, mode: 'hsi' },
 		'yellow'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 0, g: 1, b: 0 })),
 		{ h: 120, s: 1, i: 0.3333333333333333, mode: 'hsi' },
 		'green'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 0, g: 1, b: 1 })),
 		{ h: 180, s: 1, i: 0.6666666666666666, mode: 'hsi' },
 		'cyan'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 0, g: 0, b: 1 })),
 		{ h: 240, s: 1, i: 0.3333333333333333, mode: 'hsi' },
 		'blue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsi(rgb({ r: 1, g: 0, b: 1 })),
 		{ h: 300, s: 1, i: 0.6666666666666666, mode: 'hsi' },
 		'magenta'
 	);
-
-	test.end();
 });
 
-tape('color(--hsi)', t => {
-	t.deepEqual(hsi('color(--hsi 30 0.5 1 / 0.25)'), {
+test('color(--hsi)', t => {
+	assert.deepEqual(hsi('color(--hsi 30 0.5 1 / 0.25)'), {
 		h: 30,
 		s: 0.5,
 		i: 1,
 		alpha: 0.25,
 		mode: 'hsi'
 	});
-	t.deepEqual(hsi('color(--hsi 0 50% 0.5 / 25%)'), {
+	assert.deepEqual(hsi('color(--hsi 0 50% 0.5 / 25%)'), {
 		h: 0,
 		s: 0.5,
 		i: 0.5,
 		alpha: 0.25,
 		mode: 'hsi'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--hsi 0 50% 0.5 / 25%)'),
 		'color(--hsi 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--hsi none 0.5 none)'), 'hsi to rgb is ok');
-	t.deepEqual(rgb('color(--hsi none 0.5 none)'), rgb('color(--hsi 0 0.5 0'));
-	t.ok(hsi('rgb(none 100 20)'), 'rgb to hsi is ok');
-	t.deepEqual(hsi('rgb(none 100 20)'), hsi('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('color(--hsi none 0.5 none)'), 'hsi to rgb is ok');
+	assert.deepEqual(
+		rgb('color(--hsi none 0.5 none)'),
+		rgb('color(--hsi 0 0.5 0')
+	);
+	assert.ok(hsi('rgb(none 100 20)'), 'rgb to hsi is ok');
+	assert.deepEqual(hsi('rgb(none 100 20)'), hsi('rgb(0 100 20)'));
 });

--- a/test/hsl.test.js
+++ b/test/hsl.test.js
@@ -1,158 +1,153 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { hsl, rgb, formatCss } from '../src/index.js';
 
-tape('rgb() converts from HSL to RGB', function (test) {
-	test.deepEqual(
+test('rgb() converts from HSL to RGB', t => {
+	assert.deepEqual(
 		rgb(hsl({ h: 0, s: 0, l: 0 })),
 		{ r: 0, g: 0, b: 0, mode: 'rgb' },
 		'lightness 0 should yield black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsl({ h: 60, s: 0.25, l: 0 })),
 		{ r: 0, g: 0, b: 0, mode: 'rgb' },
 		'...regardless of hue and saturation'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsl({ h: 0, s: 0, l: 0.5 })),
 		{ r: 0.5, g: 0.5, b: 0.5, mode: 'rgb' },
 		'saturation 0 should yield gray'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsl({ h: 60, s: 0, l: 0.25 })),
 		{ r: 0.25, g: 0.25, b: 0.25, mode: 'rgb' },
 		'...regardless of the hue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsl({ h: 100, s: 0, l: 0.5 })),
 		{ r: 0.5, g: 0.5, b: 0.5, mode: 'rgb' },
 		'...or the lightness'
 	);
-
-	test.end();
 });
 
-tape('hsl() converts RGB to HSL', function (test) {
-	test.deepEqual(
+test('hsl() converts RGB to HSL', t => {
+	assert.deepEqual(
 		hsl(rgb({ r: 0, g: 0, b: 0 })),
 		{ s: 0, l: 0, mode: 'hsl' },
 		'black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 0.25, g: 0.25, b: 0.25 })),
 		{ s: 0, l: 0.25, mode: 'hsl' },
 		'R = G = B yields undefined hue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 0.6, g: 0.6, b: 0.6 })),
 		{ s: 0, l: 0.6, mode: 'hsl' },
 		'R = G = B yields zero saturation'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 1, g: 0, b: 0 })),
 		{ h: 0, s: 1, l: 0.5, mode: 'hsl' },
 		'red'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 1, g: 1, b: 0 })),
 		{ h: 60, s: 1, l: 0.5, mode: 'hsl' },
 		'yellow'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 0, g: 1, b: 0 })),
 		{ h: 120, s: 1, l: 0.5, mode: 'hsl' },
 		'green'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 0, g: 1, b: 1 })),
 		{ h: 180, s: 1, l: 0.5, mode: 'hsl' },
 		'cyan'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 0, g: 0, b: 1 })),
 		{ h: 240, s: 1, l: 0.5, mode: 'hsl' },
 		'blue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl(rgb({ r: 1, g: 0, b: 1 })),
 		{ h: 300, s: 1, l: 0.5, mode: 'hsl' },
 		'magenta'
 	);
-
-	test.end();
 });
 
-tape('hsl() parses hsl / hsla CSS strings', function (test) {
-	test.deepEqual(
+test('hsl() parses hsl / hsla CSS strings', t => {
+	assert.deepEqual(
 		hsl('hsl(0, 100%, 0%)'),
 		{ s: 1, l: 0, h: 0, mode: 'hsl' },
 		'black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl('hsl(100, 0%, 50%)'),
 		{ s: 0, l: 0.5, h: 100, mode: 'hsl' },
 		'grey'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl('hsl(0, 100%, 50%)'),
 		{ h: 0, s: 1, l: 0.5, mode: 'hsl' },
 		'red'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl('hsla(219, 34%, 46%, 1)'),
 		{ mode: 'hsl', h: 219, s: 0.34, l: 0.46, alpha: 1 },
 		'alpha [0-1]'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsl('hsla(219, 34%, 46%, 25%)'),
 		{ mode: 'hsl', h: 219, s: 0.34, l: 0.46, alpha: 0.25 },
 		'alpha percentage'
 	);
-
-	test.end();
 });
 
-tape('CSS <number> in `hsl()` syntax', test => {
-	test.deepEqual(
+test('CSS <number> in `hsl()` syntax', test => {
+	assert.deepEqual(
 		hsl('hsl(3e1, 1e2%, 0.5e2%)'),
 		{ mode: 'hsl', h: 30, s: 1, l: 0.5 },
 		'exponential notation'
 	);
-	test.deepEqual(
+	assert.deepEqual(
 		hsl('hsl(30.5, 90.6%, 48.3%)'),
 		{ mode: 'hsl', h: 30.5, s: 0.9059999999999999, l: 0.483 },
 		'float values'
 	);
-	test.end();
 });
 
-tape('formatCss', t => {
-	t.equal(formatCss('hsl(.5turn 40% 20% / 50%)'), 'hsl(180 40% 20% / 0.5)');
-	t.equal(formatCss('hsl(.5turn 40% 20%)'), 'hsl(180 40% 20%)');
-	t.equal(formatCss('hsl(.5turn 40% 20% / 100%)'), 'hsl(180 40% 20%)');
-	t.equal(formatCss(hsl('#ffffff00')), 'hsl(none 0% 100% / 0)');
-	t.end();
+test('formatCss', t => {
+	assert.equal(
+		formatCss('hsl(.5turn 40% 20% / 50%)'),
+		'hsl(180 40% 20% / 0.5)'
+	);
+	assert.equal(formatCss('hsl(.5turn 40% 20%)'), 'hsl(180 40% 20%)');
+	assert.equal(formatCss('hsl(.5turn 40% 20% / 100%)'), 'hsl(180 40% 20%)');
+	assert.equal(formatCss(hsl('#ffffff00')), 'hsl(none 0% 100% / 0)');
 });
 
-tape('missing components', t => {
-	t.ok(rgb('hsl(none 50% none)'));
-	t.deepEqual(rgb('hsl(none 50% none)'), rgb('hsl(0deg 50% 0%)'));
-	t.ok(hsl('rgb(none 100 20)'));
-	t.deepEqual(hsl('rgb(none 100 20)'), hsl('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('hsl(none 50% none)'));
+	assert.deepEqual(rgb('hsl(none 50% none)'), rgb('hsl(0deg 50% 0%)'));
+	assert.ok(hsl('rgb(none 100 20)'));
+	assert.deepEqual(hsl('rgb(none 100 20)'), hsl('rgb(0 100 20)'));
 });

--- a/test/hsv.test.js
+++ b/test/hsv.test.js
@@ -1,133 +1,129 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { hsv, rgb, formatCss } from '../src/index.js';
 
-tape('rgb() converts from HSV to RGB', function (test) {
-	test.deepEqual(
+test('rgb() converts from HSV to RGB', t => {
+	assert.deepEqual(
 		rgb(hsv({ h: 0, s: 0, v: 0 })),
 		{ r: 0, g: 0, b: 0, mode: 'rgb' },
 		'lightness 0 should yield black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsv({ h: 60, s: 0.25, v: 0 })),
 		{ r: 0, g: 0, b: 0, mode: 'rgb' },
 		'...regardless of hue and saturation'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsv({ h: 0, s: 0, v: 0.5 })),
 		{ r: 0.5, g: 0.5, b: 0.5, mode: 'rgb' },
 		'saturation 0 should yield gray'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsv({ h: 60, s: 0, v: 0.25 })),
 		{ r: 0.25, g: 0.25, b: 0.25, mode: 'rgb' },
 		'...regardless of the hue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb(hsv({ h: 100, s: 0, v: 0.5 })),
 		{ r: 0.5, g: 0.5, b: 0.5, mode: 'rgb' },
 		'...or the lightness'
 	);
-
-	test.end();
 });
 
-tape('hsv() converts RGB to HSV', function (test) {
-	test.deepEqual(
+test('hsv() converts RGB to HSV', t => {
+	assert.deepEqual(
 		hsv(rgb({ r: 0, g: 0, b: 0 })),
 		{ s: 0, v: 0, mode: 'hsv' },
 		'black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 0.25, g: 0.25, b: 0.25 })),
 		{ s: 0, v: 0.25, mode: 'hsv' },
 		'R = G = B yields undefined hue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 0.6, g: 0.6, b: 0.6 })),
 		{ s: 0, v: 0.6, mode: 'hsv' },
 		'R = G = B yields zero saturation'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 1, g: 0, b: 0 })),
 		{ h: 0, s: 1, v: 1, mode: 'hsv' },
 		'red'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 1, g: 1, b: 0 })),
 		{ h: 60, s: 1, v: 1, mode: 'hsv' },
 		'yellow'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 0, g: 1, b: 0 })),
 		{ h: 120, s: 1, v: 1, mode: 'hsv' },
 		'green'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 0, g: 1, b: 1 })),
 		{ h: 180, s: 1, v: 1, mode: 'hsv' },
 		'cyan'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 0, g: 0, b: 1 })),
 		{ h: 240, s: 1, v: 1, mode: 'hsv' },
 		'blue'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hsv(rgb({ r: 1, g: 0, b: 1 })),
 		{ h: 300, s: 1, v: 1, mode: 'hsv' },
 		'magenta'
 	);
-
-	test.end();
 });
 
-tape('hsv(str)', function (test) {
-	test.deepEqual(hsv('white'), { mode: 'hsv', s: 0, v: 1 });
-	test.end();
+test('hsv(str)', t => {
+	assert.deepEqual(hsv('white'), { mode: 'hsv', s: 0, v: 1 });
 });
 
-tape('color(--hsv)', t => {
-	t.deepEqual(hsv('color(--hsv 30 0.5 1 / 0.25)'), {
+test('color(--hsv)', t => {
+	assert.deepEqual(hsv('color(--hsv 30 0.5 1 / 0.25)'), {
 		h: 30,
 		s: 0.5,
 		v: 1,
 		alpha: 0.25,
 		mode: 'hsv'
 	});
-	t.deepEqual(hsv('color(--hsv 0 50% 0.5 / 25%)'), {
+	assert.deepEqual(hsv('color(--hsv 0 50% 0.5 / 25%)'), {
 		h: 0,
 		s: 0.5,
 		v: 0.5,
 		alpha: 0.25,
 		mode: 'hsv'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--hsv 0 50% 0.5 / 25%)'),
 		'color(--hsv 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--hsv none 0.5 none)'), 'hsv to rgb is ok');
-	t.deepEqual(rgb('color(--hsv none 0.5 none)'), rgb('color(--hsv 0 0.5 0'));
-	t.ok(hsv('rgb(none 100 20)'), 'rgb to hsv is ok');
-	t.deepEqual(hsv('rgb(none 100 20)'), hsv('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('color(--hsv none 0.5 none)'), 'hsv to rgb is ok');
+	assert.deepEqual(
+		rgb('color(--hsv none 0.5 none)'),
+		rgb('color(--hsv 0 0.5 0')
+	);
+	assert.ok(hsv('rgb(none 100 20)'), 'rgb to hsv is ok');
+	assert.deepEqual(hsv('rgb(none 100 20)'), hsv('rgb(0 100 20)'));
 });

--- a/test/hwb.test.js
+++ b/test/hwb.test.js
@@ -1,55 +1,54 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { hwb, rgb, formatCss } from '../src/index.js';
 
-tape('hwb() parses hwb CSS strings', function (test) {
-	test.deepEqual(
+test('hwb() parses hwb CSS strings', t => {
+	assert.deepEqual(
 		hwb('hwb(100 0% 0%)'),
 		{ h: 100, w: 0, b: 0, mode: 'hwb' },
 		'black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hwb('hwb(200 150% 150%)'),
 		{ h: 200, w: 1.5, b: 1.5, mode: 'hwb' },
 		'grey'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hwb('hwb(200 150% 50% / 50%)'),
 		{ h: 200, w: 1.5, b: 0.5, mode: 'hwb', alpha: 0.5 },
 		'grey (alpha [0-1])'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		hwb('hwb(200 150% 50% / .5)'),
 		{ h: 200, w: 1.5, b: 0.5, mode: 'hwb', alpha: 0.5 },
 		'grey (alpha percentage)'
 	);
-
-	test.end();
 });
 
-tape('formatCss', t => {
-	t.equal(formatCss('hwb(200 150% 50% / .5)'), 'hwb(200 150% 50% / 0.5)');
-	t.equal(formatCss('hwb(200 150% 50% / 100%)'), 'hwb(200 150% 50%)');
-	t.equal(formatCss('hwb(200 150% 50%)'), 'hwb(200 150% 50%)');
-	t.equal(formatCss(hwb('#ffffff00')), 'hwb(none 100% 0% / 0)');
-	t.end();
+test('formatCss', t => {
+	assert.equal(
+		formatCss('hwb(200 150% 50% / .5)'),
+		'hwb(200 150% 50% / 0.5)'
+	);
+	assert.equal(formatCss('hwb(200 150% 50% / 100%)'), 'hwb(200 150% 50%)');
+	assert.equal(formatCss('hwb(200 150% 50%)'), 'hwb(200 150% 50%)');
+	assert.equal(formatCss(hwb('#ffffff00')), 'hwb(none 100% 0% / 0)');
 });
 
-tape('missing components', t => {
-	t.ok(rgb('hwb(none 50% none)'));
-	t.deepEqual(rgb('hwb(none 50% none)'), rgb('hwb(0deg 50% 0%'));
-	t.ok(hwb('rgb(none 100 20)'));
-	t.deepEqual(hwb('rgb(none 100 20)'), hwb('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('hwb(none 50% none)'));
+	assert.deepEqual(rgb('hwb(none 50% none)'), rgb('hwb(0deg 50% 0%'));
+	assert.ok(hwb('rgb(none 100 20)'));
+	assert.deepEqual(hwb('rgb(none 100 20)'), hwb('rgb(0 100 20)'));
 });
 
-tape('powerless components', t => {
-	t.deepEqual(hwb(rgb('hwb(60deg 75% 50%)')), {
+test('powerless components', t => {
+	assert.deepEqual(hwb(rgb('hwb(60deg 75% 50%)')), {
 		mode: 'hwb',
 		w: 0.6,
 		b: 0.4
 	});
-	t.end();
 });

--- a/test/interpolate.test.js
+++ b/test/interpolate.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	interpolate,
 	interpolateWith,
@@ -9,237 +10,227 @@ import {
 	samples
 } from '../src/index.js';
 
-tape('interpolate between black and white in RGB', function (test) {
+test('interpolate between black and white in RGB', t => {
 	let grays = interpolate(['#fff', '#000']);
-	test.equal(formatHex(grays(0.0)), '#ffffff');
-	test.equal(formatHex(grays(0.1)), '#e6e6e6');
-	test.equal(formatHex(grays(0.2)), '#cccccc');
-	test.equal(formatHex(grays(0.3)), '#b3b3b3');
-	test.equal(formatHex(grays(0.4)), '#999999');
-	test.equal(formatHex(grays(0.5)), '#808080');
-	test.equal(formatHex(grays(0.6)), '#666666');
-	test.equal(formatHex(grays(0.7)), '#4d4d4d');
-	test.equal(formatHex(grays(0.8)), '#333333');
-	test.equal(formatHex(grays(0.9)), '#191919');
-	test.equal(formatHex(grays(1.0)), '#000000');
-	test.end();
+	assert.equal(formatHex(grays(0.0)), '#ffffff');
+	assert.equal(formatHex(grays(0.1)), '#e6e6e6');
+	assert.equal(formatHex(grays(0.2)), '#cccccc');
+	assert.equal(formatHex(grays(0.3)), '#b3b3b3');
+	assert.equal(formatHex(grays(0.4)), '#999999');
+	assert.equal(formatHex(grays(0.5)), '#808080');
+	assert.equal(formatHex(grays(0.6)), '#666666');
+	assert.equal(formatHex(grays(0.7)), '#4d4d4d');
+	assert.equal(formatHex(grays(0.8)), '#333333');
+	assert.equal(formatHex(grays(0.9)), '#191919');
+	assert.equal(formatHex(grays(1.0)), '#000000');
 });
 
-tape('interpolate between black and white in RGBA', function (test) {
+test('interpolate between black and white in RGBA', t => {
 	let grays = interpolate(['#ffff', '#0000']);
-	test.deepEqual(rgb(grays(0.0)), {
+	assert.deepEqual(rgb(grays(0.0)), {
 		r: 1,
 		g: 1,
 		b: 1,
 		alpha: 1,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.1)), {
+	assert.deepEqual(rgb(grays(0.1)), {
 		r: 0.9,
 		g: 0.9,
 		b: 0.9,
 		alpha: 0.9,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.2)), {
+	assert.deepEqual(rgb(grays(0.2)), {
 		r: 0.8,
 		g: 0.8,
 		b: 0.8,
 		alpha: 0.8,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.3)), {
+	assert.deepEqual(rgb(grays(0.3)), {
 		r: 0.7,
 		g: 0.7,
 		b: 0.7,
 		alpha: 0.7,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.4)), {
+	assert.deepEqual(rgb(grays(0.4)), {
 		r: 0.6,
 		g: 0.6,
 		b: 0.6,
 		alpha: 0.6,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.5)), {
+	assert.deepEqual(rgb(grays(0.5)), {
 		r: 0.5,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.5,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.6)), {
+	assert.deepEqual(rgb(grays(0.6)), {
 		r: 0.4,
 		g: 0.4,
 		b: 0.4,
 		alpha: 0.4,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.7)), {
+	assert.deepEqual(rgb(grays(0.7)), {
 		r: 0.30000000000000004,
 		g: 0.30000000000000004,
 		b: 0.30000000000000004,
 		alpha: 0.30000000000000004,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.8)), {
+	assert.deepEqual(rgb(grays(0.8)), {
 		r: 0.19999999999999996,
 		g: 0.19999999999999996,
 		b: 0.19999999999999996,
 		alpha: 0.19999999999999996,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.9)), {
+	assert.deepEqual(rgb(grays(0.9)), {
 		r: 0.09999999999999998,
 		g: 0.09999999999999998,
 		b: 0.09999999999999998,
 		alpha: 0.09999999999999998,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(1.0)), {
+	assert.deepEqual(rgb(grays(1.0)), {
 		r: 0,
 		g: 0,
 		b: 0,
 		alpha: 0,
 		mode: 'rgb'
 	});
-	test.end();
 });
 
-tape('interpolate between black and white in RGB/RGBA', function (test) {
+test('interpolate between black and white in RGB/RGBA', t => {
 	let grays = interpolate(['#fff', '#0000']);
-	test.deepEqual(rgb(grays(0.0)), {
+	assert.deepEqual(rgb(grays(0.0)), {
 		r: 1,
 		g: 1,
 		b: 1,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.1)), {
+	assert.deepEqual(rgb(grays(0.1)), {
 		r: 0.9,
 		g: 0.9,
 		b: 0.9,
 		alpha: 0.9,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.2)), {
+	assert.deepEqual(rgb(grays(0.2)), {
 		r: 0.8,
 		g: 0.8,
 		b: 0.8,
 		alpha: 0.8,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.3)), {
+	assert.deepEqual(rgb(grays(0.3)), {
 		r: 0.7,
 		g: 0.7,
 		b: 0.7,
 		alpha: 0.7,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.4)), {
+	assert.deepEqual(rgb(grays(0.4)), {
 		r: 0.6,
 		g: 0.6,
 		b: 0.6,
 		alpha: 0.6,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.5)), {
+	assert.deepEqual(rgb(grays(0.5)), {
 		r: 0.5,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.5,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.6)), {
+	assert.deepEqual(rgb(grays(0.6)), {
 		r: 0.4,
 		g: 0.4,
 		b: 0.4,
 		alpha: 0.4,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.7)), {
+	assert.deepEqual(rgb(grays(0.7)), {
 		r: 0.30000000000000004,
 		g: 0.30000000000000004,
 		b: 0.30000000000000004,
 		alpha: 0.30000000000000004,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.8)), {
+	assert.deepEqual(rgb(grays(0.8)), {
 		r: 0.19999999999999996,
 		g: 0.19999999999999996,
 		b: 0.19999999999999996,
 		alpha: 0.19999999999999996,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(0.9)), {
+	assert.deepEqual(rgb(grays(0.9)), {
 		r: 0.09999999999999998,
 		g: 0.09999999999999998,
 		b: 0.09999999999999998,
 		alpha: 0.09999999999999998,
 		mode: 'rgb'
 	});
-	test.deepEqual(rgb(grays(1.0)), {
+	assert.deepEqual(rgb(grays(1.0)), {
 		r: 0,
 		g: 0,
 		b: 0,
 		alpha: 0,
 		mode: 'rgb'
 	});
-	test.end();
 });
 
-tape('bug checking', function (test) {
-	test.deepEqual(
+test('bug checking', t => {
+	assert.deepEqual(
 		samples(4)
 			.map(interpolate(['blue', 'white'], 'hsv'))
 			.map(formatHex),
 		['#0000ff', '#5555ff', '#aaaaff', '#ffffff']
 	);
-	test.end();
 });
 
-tape('color interpolation hints', t => {
+test('color interpolation hints', t => {
 	[0, 0.1, 0.2, 0.5, 0.8, 1].forEach(t0 => {
-		t.deepEqual(
+		assert.deepEqual(
 			interpolate(['red', 0.5, 'green'])(t0),
 			interpolate(['red', 'green'])(t0)
 		);
 	});
 
-	t.deepEqual(interpolate(['red', 0.2, 'green'])(0.5), {
+	assert.deepEqual(interpolate(['red', 0.2, 'green'])(0.5), {
 		mode: 'rgb',
 		r: 0.25808621995139025,
 		g: 0.372411622926361,
 		b: 0
 	});
-
-	t.end();
 });
 
-tape('interpolateWith()', t => {
+test('interpolateWith()', t => {
 	let colors = ['red', ['transparent', 0.33], 'blue'];
 	let it2 = interpolateWith(v => v / 2)(colors);
 
-	t.equal(formatHex8(it2(0.25)), '#1f00001f', 'w premultiplication');
-	t.equal(formatHex8(it2(0.75)), '#00005050', 'w premultiplication');
-
-	t.end();
+	assert.equal(formatHex8(it2(0.25)), '#1f00001f', 'w premultiplication');
+	assert.equal(formatHex8(it2(0.75)), '#00005050', 'w premultiplication');
 });
 
-tape('interpolateWithPremultipliedAlpha()', t => {
+test('interpolateWithPremultipliedAlpha()', t => {
 	let colors = ['red', 'transparent', 'blue'];
 	let it = interpolate(colors);
 	let it2 = interpolateWithPremultipliedAlpha(colors);
 
-	t.equal(formatHex8(it(0.25)), '#80000080', 'w/o premultiplication');
-	t.equal(formatHex8(it(0.75)), '#00008080', 'w/o premultiplication');
-	t.equal(formatHex8(it2(0.25)), '#ff000080', 'w premultiplication');
-	t.equal(formatHex8(it2(0.75)), '#0000ff80', 'w premultiplication');
-
-	t.end();
+	assert.equal(formatHex8(it(0.25)), '#80000080', 'w/o premultiplication');
+	assert.equal(formatHex8(it(0.75)), '#00008080', 'w/o premultiplication');
+	assert.equal(formatHex8(it2(0.25)), '#ff000080', 'w premultiplication');
+	assert.equal(formatHex8(it2(0.75)), '#0000ff80', 'w premultiplication');
 });
 
-tape('Easing fn returning outside [0,1], issue #140', t => {
+test('Easing fn returning outside [0,1], issue #140', t => {
 	// From: https://github.com/mattdesl/eases/blob/master/back-in-out.js
 	function backInOut(t) {
 		var s = 1.70158 * 1.525;
@@ -248,7 +239,6 @@ tape('Easing fn returning outside [0,1], issue #140', t => {
 			: 0.5 * ((t -= 2) * t * ((s + 1) * t + s) + 2);
 	}
 	const it = interpolate([backInOut, '#ff0000', '#cc8833', '#3344cc']);
-	t.equal(isNaN(it(0.05).r), false);
-	t.equal(isNaN(it(0.95).r), false);
-	t.end();
+	assert.equal(isNaN(it(0.05).r), false);
+	assert.equal(isNaN(it(0.95).r), false);
 });

--- a/test/interpolatorLinear.test.js
+++ b/test/interpolatorLinear.test.js
@@ -1,9 +1,10 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { samples, interpolatorLinear } from '../src/index.js';
 
-tape('interpolatorLinear', t => {
+test('interpolatorLinear', t => {
 	let data = [3, 2.8, 2.5, 1, 0.95, 0.8, 0.5, 0.1, 0.05];
-	t.deepEqual(
+	assert.deepEqual(
 		samples(10).map(interpolatorLinear(data)),
 		[
 			3, 2.822222222222222, 2.5666666666666664, 1.5000000000000002,
@@ -11,14 +12,12 @@ tape('interpolatorLinear', t => {
 			0.4111111111111111, 0.09444444444444447, 0.05
 		]
 	);
-	t.end();
 });
 
-tape('outside [0, 1] range', t => {
+test('outside [0, 1] range', t => {
 	let it = interpolatorLinear([3, 10, 1]);
-	t.equal(it(-0.5), -4);
-	t.equal(it(-1), -11);
-	t.equal(it(1.5), -8);
-	t.equal(it(2), -17);
-	t.end();
+	assert.equal(it(-0.5), -4);
+	assert.equal(it(-1), -11);
+	assert.equal(it(1.5), -8);
+	assert.equal(it(2), -17);
 });

--- a/test/interpolatorSplineBasis.test.js
+++ b/test/interpolatorSplineBasis.test.js
@@ -1,13 +1,14 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	samples,
 	interpolatorSplineBasis,
 	interpolatorSplineBasisClosed
 } from '../src/index.js';
 
-tape('interpolatorSplineBasis', t => {
+test('interpolatorSplineBasis', t => {
 	let data = [3, 2.8, 2.5, 1, 0.95, 0.8, 0.5, 0.1, 0.05];
-	t.deepEqual(
+	assert.deepEqual(
 		samples(10).map(interpolatorSplineBasis(data)),
 		[
 			3, 2.810516689529035, 2.472382258802012, 1.5641975308641978,
@@ -15,12 +16,11 @@ tape('interpolatorSplineBasis', t => {
 			0.4039094650205761, 0.13541380887059906, 0.05000000000000001
 		]
 	);
-	t.end();
 });
 
-tape('interpolatorSplineBasisClosed', t => {
+test('interpolatorSplineBasisClosed', t => {
 	let data = [3, 2.8, 2.5, 1, 0.95, 0.8, 0.5, 0.1, 0.05];
-	t.deepEqual(
+	assert.deepEqual(
 		samples(10).map(interpolatorSplineBasisClosed(data)),
 		[
 			2.475, 2.8097965249199817, 2.472382258802012, 1.5641975308641978,
@@ -28,26 +28,23 @@ tape('interpolatorSplineBasisClosed', t => {
 			0.4039094650205761, 0.1360996799268405, 0.5499999999999999
 		]
 	);
-	t.end();
 });
 
-tape('interpolatorSplineBasis: outside [0, 1] range', t => {
+test('interpolatorSplineBasis: outside [0, 1] range', t => {
 	let it = interpolatorSplineBasis([3, 10, 1]);
-	t.deepEqual(
+	assert.deepEqual(
 		[-0.5, 1, 1.5, 2].map(it),
 		[-1.3333333333333333, 1, -5.333333333333333, 4.333333333333333]
 	);
-	t.end();
 });
 
-tape('interpolatorSplineBasisClosed: outside [0, 1] range', t => {
+test('interpolatorSplineBasisClosed: outside [0, 1] range', t => {
 	let it = interpolatorSplineBasisClosed([3, 10, 1]);
-	t.deepEqual(
+	assert.deepEqual(
 		[-0.5, 1, 1.5, 2].map(it),
 		[
 			2.8333333333333335, 2.8333333333333335, 3.8333333333333335,
 			7.333333333333333
 		]
 	);
-	t.end();
 });

--- a/test/interpolatorSplineMonotone.test.js
+++ b/test/interpolatorSplineMonotone.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	samples,
 	interpolatorSplineMonotone,
@@ -6,9 +7,9 @@ import {
 	interpolatorSplineMonotoneClosed
 } from '../src/index.js';
 
-tape('interpolatorSplineMonotone', t => {
+test('interpolatorSplineMonotone', t => {
 	let data = [3, 2.8, 2.5, 1, 0.95, 0.8, 0.5, 0.1, 0.05];
-	t.deepEqual(
+	assert.deepEqual(
 		samples(10).map(interpolatorSplineMonotone(data)),
 		[
 			3, 2.826611796982167, 2.6089163237311386, 1.3592592592592596,
@@ -16,12 +17,11 @@ tape('interpolatorSplineMonotone', t => {
 			0.40631001371742104, 0.09005486968449936, 0.049999999999999975
 		]
 	);
-	t.end();
 });
 
-tape('interpolatorSplineMonotone2', t => {
+test('interpolatorSplineMonotone2', t => {
 	let data = [3, 2.8, 2.5, 1, 0.95, 0.8, 0.5, 0.1, 0.05];
-	t.deepEqual(
+	assert.deepEqual(
 		samples(10).map(interpolatorSplineMonotone2(data)),
 		[
 			3, 2.82716049382716, 2.6089163237311386, 1.3592592592592596,
@@ -29,12 +29,11 @@ tape('interpolatorSplineMonotone2', t => {
 			0.40631001371742104, 0.08950617283950621, 0.04999999999999999
 		]
 	);
-	t.end();
 });
 
-tape('interpolatorSplineMonotoneClosed', t => {
+test('interpolatorSplineMonotoneClosed', t => {
 	let data = [3, 2.8, 2.5, 1, 0.95, 0.8, 0.5, 0.1, 0.05];
-	t.deepEqual(
+	assert.deepEqual(
 		samples(10).map(interpolatorSplineMonotoneClosed(data)),
 		[
 			3, 2.8288065843621397, 2.6089163237311386, 1.3592592592592596,
@@ -42,23 +41,19 @@ tape('interpolatorSplineMonotoneClosed', t => {
 			0.40631001371742104, 0.08950617283950621, 0.04999999999999999
 		]
 	);
-	t.end();
 });
 
-tape('interpolatorSplineMonotone: outside [0, 1] range', t => {
+test('interpolatorSplineMonotone: outside [0, 1] range', t => {
 	let it = interpolatorSplineMonotone([3, 10, 1]);
-	t.deepEqual([-0.5, 1, 1.5, 2].map(it), [10, 1, 10, 91]);
-	t.end();
+	assert.deepEqual([-0.5, 1, 1.5, 2].map(it), [10, 1, 10, 91]);
 });
 
-tape('interpolatorSplineMonotone2: outside [0, 1] range', t => {
+test('interpolatorSplineMonotone2: outside [0, 1] range', t => {
 	let it = interpolatorSplineMonotone2([3, 10, 1]);
-	t.deepEqual([-0.5, 1, 1.5, 2].map(it), [-18, 1, -22, -53]);
-	t.end();
+	assert.deepEqual([-0.5, 1, 1.5, 2].map(it), [-18, 1, -22, -53]);
 });
 
-tape('interpolatorSplineMonotoneClosed: outside [0, 1] range', t => {
+test('interpolatorSplineMonotoneClosed: outside [0, 1] range', t => {
 	let it = interpolatorSplineMonotoneClosed([3, 10, 1]);
-	t.deepEqual([-0.5, 1, 1.5, 2].map(it), [22, 1, 46, 253]);
-	t.end();
+	assert.deepEqual([-0.5, 1, 1.5, 2].map(it), [22, 1, 46, 253]);
 });

--- a/test/interpolatorSplineNatural.test.js
+++ b/test/interpolatorSplineNatural.test.js
@@ -1,41 +1,38 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	samples,
 	interpolatorSplineNatural,
 	interpolatorSplineNaturalClosed
 } from '../src/index.js';
 
-tape('interpolatorSplineNatural', t => {
+test('interpolatorSplineNatural', t => {
 	let arr = [10, 20, 0, 40, 70];
 	let it = interpolatorSplineNatural(arr);
-	t.deepEqual(samples(5).map(it), arr);
-	t.end();
+	assert.deepEqual(samples(5).map(it), arr);
 });
 
-tape('interpolatorSplineNaturalClosed', t => {
+test('interpolatorSplineNaturalClosed', t => {
 	let arr = [10, 20, 0, 40, 70];
 	let it = interpolatorSplineNaturalClosed(arr);
-	t.deepEqual(samples(5).map(it), [23.75, 20, 0, 40, 56.25]);
-	t.end();
+	assert.deepEqual(samples(5).map(it), [23.75, 20, 0, 40, 56.25]);
 });
 
-tape('interpolatorSplineNatural: outside [0, 1] range', t => {
+test('interpolatorSplineNatural: outside [0, 1] range', t => {
 	let it = interpolatorSplineNatural([3, 10, 1]);
-	t.deepEqual(
+	assert.deepEqual(
 		[-0.5, 1, 1.5, 2].map(it),
 		[-4.166666666666667, 1, -8.166666666666666, 7.166666666666667]
 	);
-	t.end();
 });
 
-tape('interpolatorSplineNaturalClosed: outside [0, 1] range', t => {
+test('interpolatorSplineNaturalClosed: outside [0, 1] range', t => {
 	let it = interpolatorSplineNaturalClosed([3, 10, 1]);
-	t.deepEqual(
+	assert.deepEqual(
 		[-0.5, 1, 1.5, 2].map(it),
 		[
 			3.5416666666666665, 3.5416666666666665, 4.541666666666667,
 			10.166666666666666
 		]
 	);
-	t.end();
 });

--- a/test/itp.test.js
+++ b/test/itp.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { formatCss, formatHex, itp } from '../src/index.js';
 
-tape('itp', t => {
-	t.deepEqual(
+test('itp', t => {
+	assert.deepEqual(
 		itp('white'),
 		{
 			mode: 'itp',
@@ -12,7 +13,7 @@ tape('itp', t => {
 		},
 		'white'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		itp('black'),
 		{
 			mode: 'itp',
@@ -22,7 +23,7 @@ tape('itp', t => {
 		},
 		'black'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		itp('red'),
 		{
 			mode: 'itp',
@@ -32,37 +33,34 @@ tape('itp', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(--ictcp)', t => {
-	t.deepEqual(itp('color(--ictcp 1 0 0 / 0.25)'), {
+test('color(--ictcp)', t => {
+	assert.deepEqual(itp('color(--ictcp 1 0 0 / 0.25)'), {
 		mode: 'itp',
 		i: 1,
 		t: 0,
 		p: 0,
 		alpha: 0.25
 	});
-	t.deepEqual(itp('color(--ictcp 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(itp('color(--ictcp 0% 50% 0.5 / 25%)'), {
 		mode: 'itp',
 		i: 0,
 		t: 0.5,
 		p: 0.5,
 		alpha: 0.25
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--ictcp 0% 50% 0.5 / 25%)'),
 		'color(--ictcp 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatHex({
 			mode: 'itp',
 			i: 0.4278802843622844,
@@ -72,5 +70,4 @@ tape('formatCss', t => {
 		'#ff0000',
 		'red'
 	);
-	t.end();
 });

--- a/test/jab.test.js
+++ b/test/jab.test.js
@@ -1,20 +1,21 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { jab, rgb, formatHex, formatCss } from '../src/index.js';
 
-tape('jab', t => {
-	t.deepEqual(
+test('jab', t => {
+	assert.deepEqual(
 		jab('white'),
 		{ mode: 'jab', j: 0.222065249535743, a: 0, b: 0 },
 		'white'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		jab('black'),
 		{ mode: 'jab', j: 3.2311742677852644e-27, a: 0, b: 0 },
 		'black'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		jab('red'),
 		{
 			mode: 'jab',
@@ -24,40 +25,35 @@ tape('jab', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('rgb -> jab -> rgb', t => {
-	t.equal(formatHex(jab('#cc3302')), '#cc3302', '#cc3302');
-	t.end();
+test('rgb -> jab -> rgb', t => {
+	assert.equal(formatHex(jab('#cc3302')), '#cc3302', '#cc3302');
 });
 
-tape('color(--jzazbz)', t => {
-	t.deepEqual(jab('color(--jzazbz 30 -10 +15 / 0.25)'), {
+test('color(--jzazbz)', t => {
+	assert.deepEqual(jab('color(--jzazbz 30 -10 +15 / 0.25)'), {
 		j: 30,
 		a: -10,
 		b: +15,
 		alpha: 0.25,
 		mode: 'jab'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--jzazbz 30 -1e1 +15 / 0.25)'),
 		'color(--jzazbz 30 -10 15 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--jzazbz none 0.5 none)'), 'jab to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--jzazbz none 0.5 none)'), 'jab to rgb is ok');
+	assert.deepEqual(
 		rgb('color(--jzazbz none 0.5 none)'),
 		rgb('color(--jzazbz 0 0.5 0)')
 	);
-	t.ok(jab('rgb(none 100 20)'), 'rgb to jab is ok');
-	t.deepEqual(jab('rgb(none 100 20)'), jab('rgb(0 100 20)'));
-	t.end();
+	assert.ok(jab('rgb(none 100 20)'), 'rgb to jab is ok');
+	assert.deepEqual(jab('rgb(none 100 20)'), jab('rgb(0 100 20)'));
 });

--- a/test/jch.test.js
+++ b/test/jch.test.js
@@ -1,40 +1,37 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { formatRgb, formatCss, jch, rgb } from '../src/index.js';
 
-tape('PQ_inv negative value', t => {
-	t.equal(
+test('PQ_inv negative value', t => {
+	assert.equal(
 		formatRgb({ mode: 'jch', j: 0.01768, c: 0.095, h: 77 }),
 		'rgb(42, 0, 0)'
 	);
-	t.end();
 });
 
-tape('color(--jzczhz)', t => {
-	t.deepEqual(jch('color(--jzczhz 30 10e1 -15 / 0.25)'), {
+test('color(--jzczhz)', t => {
+	assert.deepEqual(jch('color(--jzczhz 30 10e1 -15 / 0.25)'), {
 		j: 30,
 		c: 100,
 		h: -15,
 		alpha: 0.25,
 		mode: 'jch'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--jzczhz 30 1e1 +15 / 0.25)'),
 		'color(--jzczhz 30 10 15 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--jzczhz none 0.5 none)'), 'jch to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--jzczhz none 0.5 none)'), 'jch to rgb is ok');
+	assert.deepEqual(
 		rgb('color(--jzczhz none 0.5 none)'),
 		rgb('color(--jzczhz 0% 0.5 0)')
 	);
-	t.ok(jch('rgb(none 100 20)'), 'rgb to jch is ok');
-	t.deepEqual(jch('rgb(none 100 20)'), jch('rgb(0 100 20)'));
-	t.end();
+	assert.ok(jch('rgb(none 100 20)'), 'rgb to jch is ok');
+	assert.deepEqual(jch('rgb(none 100 20)'), jch('rgb(0 100 20)'));
 });

--- a/test/lab.test.js
+++ b/test/lab.test.js
@@ -1,22 +1,23 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { lab, rgb, formatCss } from '../src/index.js';
 
-tape('lab', t => {
-	t.deepEqual(
+test('lab', t => {
+	assert.deepEqual(
 		lab('white'),
 		{ mode: 'lab', l: 100.00000139649632, a: 0, b: 0 },
 		'white'
 	);
 
 	// Tests that achromatic RGB colors get a = b = 0 in CIELab
-	t.deepEqual(
+	assert.deepEqual(
 		lab('#111'),
 		{ mode: 'lab', l: 5.063329676301251, a: 0, b: 0 },
 		'#111'
 	);
 
-	t.deepEqual(lab('black'), { mode: 'lab', l: 0, a: 0, b: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(lab('black'), { mode: 'lab', l: 0, a: 0, b: 0 }, 'black');
+	assert.deepEqual(
 		lab('red'),
 		{
 			mode: 'lab',
@@ -27,27 +28,24 @@ tape('lab', t => {
 		'red'
 	);
 
-	t.deepEqual(lab('lab(50% -10% 200% / 10%)'), {
+	assert.deepEqual(lab('lab(50% -10% 200% / 10%)'), {
 		mode: 'lab',
 		l: 50,
 		a: -12.5,
 		b: 250,
 		alpha: 0.1
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(formatCss('lab(40% 10 30 / 50%)'), 'lab(40 10 30 / 0.5)');
-	t.equal(formatCss('lab(40% 10 30 / 100%)'), 'lab(40 10 30)');
-	t.equal(formatCss('lab(40% 10 30)'), 'lab(40 10 30)');
-	t.end();
+test('formatCss', t => {
+	assert.equal(formatCss('lab(40% 10 30 / 50%)'), 'lab(40 10 30 / 0.5)');
+	assert.equal(formatCss('lab(40% 10 30 / 100%)'), 'lab(40 10 30)');
+	assert.equal(formatCss('lab(40% 10 30)'), 'lab(40 10 30)');
 });
 
-tape('missing components', t => {
-	t.ok(rgb('lab(none 0.5 none)'), 'lab to rgb is ok');
-	t.deepEqual(rgb('lab(none 0.5 none)'), rgb('lab(0% 0.5 0%)'));
-	t.ok(lab('rgb(none 100 20)'), 'rgb to lab is ok');
-	t.deepEqual(lab('rgb(none 100 20)'), lab('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('lab(none 0.5 none)'), 'lab to rgb is ok');
+	assert.deepEqual(rgb('lab(none 0.5 none)'), rgb('lab(0% 0.5 0%)'));
+	assert.ok(lab('rgb(none 100 20)'), 'rgb to lab is ok');
+	assert.deepEqual(lab('rgb(none 100 20)'), lab('rgb(0 100 20)'));
 });

--- a/test/lab65.test.js
+++ b/test/lab65.test.js
@@ -1,18 +1,27 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { lab65, rgb, formatCss } from '../src/index.js';
 
-tape('lab65', t => {
-	t.deepEqual(lab65('white'), { mode: 'lab65', l: 100, a: 0, b: 0 }, 'white');
+test('lab65', t => {
+	assert.deepEqual(
+		lab65('white'),
+		{ mode: 'lab65', l: 100, a: 0, b: 0 },
+		'white'
+	);
 
 	// Tests that achromatic RGB colors get a = b = 0 in CIELab D65
-	t.deepEqual(
+	assert.deepEqual(
 		lab65('#111'),
 		{ mode: 'lab65', l: 5.063329493432597, a: 0, b: 0 },
 		'#111'
 	);
 
-	t.deepEqual(lab65('black'), { mode: 'lab65', l: 0, a: 0, b: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(
+		lab65('black'),
+		{ mode: 'lab65', l: 0, a: 0, b: 0 },
+		'black'
+	);
+	assert.deepEqual(
 		lab65('red'),
 		{
 			mode: 'lab65',
@@ -22,35 +31,31 @@ tape('lab65', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(--lab-d65)', t => {
-	t.deepEqual(lab65('color(--lab-d65 30 0.5 1 / 0.25)'), {
+test('color(--lab-d65)', t => {
+	assert.deepEqual(lab65('color(--lab-d65 30 0.5 1 / 0.25)'), {
 		l: 30,
 		a: 0.5,
 		b: 1,
 		alpha: 0.25,
 		mode: 'lab65'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--lab-d65 30 0.5 1 / 0.25)'),
 		'color(--lab-d65 30 0.5 1 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--lab-d65 none 0.5 none)'), 'lab65 to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--lab-d65 none 0.5 none)'), 'lab65 to rgb is ok');
+	assert.deepEqual(
 		rgb('color(--lab-d65 none 0.5 none)'),
 		rgb('color(--lab-d65 0 0.5 0)')
 	);
-	t.ok(lab65('rgb(none 100 20)'), 'rgb to lab65 is ok');
-	t.deepEqual(lab65('rgb(none 100 20)'), lab65('rgb(0 100 20)'));
-	t.end();
+	assert.ok(lab65('rgb(none 100 20)'), 'rgb to lab65 is ok');
+	assert.deepEqual(lab65('rgb(none 100 20)'), lab65('rgb(0 100 20)'));
 });

--- a/test/lch.test.js
+++ b/test/lch.test.js
@@ -1,19 +1,20 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { lch, rgb, formatCss } from '../src/index.js';
 
-tape('lch', t => {
-	t.deepEqual(
+test('lch', t => {
+	assert.deepEqual(
 		lch('white'),
 		{ mode: 'lch', l: 100.00000139649632, c: 0 },
 		'white'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		lch('#111'),
 		{ mode: 'lch', l: 5.063329676301251, c: 0 },
 		'#111'
 	);
-	t.deepEqual(lch('black'), { mode: 'lch', l: 0, c: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(lch('black'), { mode: 'lch', l: 0, c: 0 }, 'black');
+	assert.deepEqual(
 		lch('red'),
 		{
 			mode: 'lch',
@@ -23,35 +24,35 @@ tape('lch', t => {
 		},
 		'red'
 	);
-	t.deepEqual(lch('lch(20% 30% .5turn / 10%)'), {
+	assert.deepEqual(lch('lch(20% 30% .5turn / 10%)'), {
 		mode: 'lch',
 		l: 20,
 		c: 45,
 		h: 180,
 		alpha: 0.1
 	});
-	t.deepEqual(lch('lch(20% -30% .5turn / 10%)'), {
+	assert.deepEqual(lch('lch(20% -30% .5turn / 10%)'), {
 		mode: 'lch',
 		l: 20,
 		c: 0,
 		h: 180,
 		alpha: 0.1
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(formatCss('lch(40% 10 30 / 50%)'), 'lch(40 10 30 / 0.5)');
-	t.equal(formatCss('lch(40% 10 30 / 100%)'), 'lch(40 10 30)');
-	t.equal(formatCss('lch(40% 10 30)'), 'lch(40 10 30)');
-	t.equal(formatCss(lch('#ffffff00')), 'lch(100.00000139649632 0 none / 0)');
-	t.end();
+test('formatCss', t => {
+	assert.equal(formatCss('lch(40% 10 30 / 50%)'), 'lch(40 10 30 / 0.5)');
+	assert.equal(formatCss('lch(40% 10 30 / 100%)'), 'lch(40 10 30)');
+	assert.equal(formatCss('lch(40% 10 30)'), 'lch(40 10 30)');
+	assert.equal(
+		formatCss(lch('#ffffff00')),
+		'lch(100.00000139649632 0 none / 0)'
+	);
 });
 
-tape('missing components', t => {
-	t.ok(rgb('lch(none 0.5 none)'), 'lch to rgb is ok');
-	t.deepEqual(rgb('lch(none 0.5 none)'), rgb('lch(0% 0.5 0)'));
-	t.ok(lch('rgb(none 100 20)'), 'rgb to lch is ok');
-	t.deepEqual(lch('rgb(none 100 20)'), lch('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('lch(none 0.5 none)'), 'lch to rgb is ok');
+	assert.deepEqual(rgb('lch(none 0.5 none)'), rgb('lch(0% 0.5 0)'));
+	assert.ok(lch('rgb(none 100 20)'), 'rgb to lch is ok');
+	assert.deepEqual(lch('rgb(none 100 20)'), lch('rgb(0 100 20)'));
 });

--- a/test/lch65.test.js
+++ b/test/lch65.test.js
@@ -1,15 +1,16 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { lch65, lab65, formatCss } from '../src/index.js';
 
-tape('lch65', t => {
-	t.deepEqual(lch65('white'), { mode: 'lch65', l: 100, c: 0 }, 'white');
-	t.deepEqual(
+test('lch65', t => {
+	assert.deepEqual(lch65('white'), { mode: 'lch65', l: 100, c: 0 }, 'white');
+	assert.deepEqual(
 		lch65('#111'),
 		{ mode: 'lch65', l: 5.063329493432597, c: 0 },
 		'#111'
 	);
-	t.deepEqual(lch65('black'), { mode: 'lch65', l: 0, c: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(lch65('black'), { mode: 'lch65', l: 0, c: 0 }, 'black');
+	assert.deepEqual(
 		lch65('red'),
 		{
 			mode: 'lch65',
@@ -19,18 +20,17 @@ tape('lch65', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('lab65 <-> lch65', t => {
-	t.deepEqual(lch65(lab65({ l: 100, a: 0.2, b: 0.2 })), {
+test('lab65 <-> lch65', t => {
+	assert.deepEqual(lch65(lab65({ l: 100, a: 0.2, b: 0.2 })), {
 		mode: 'lch65',
 		l: 100,
 		c: 0.28284271247461906,
 		h: 45
 	});
 
-	t.deepEqual(
+	assert.deepEqual(
 		lab65(
 			lch65({
 				mode: 'lch65',
@@ -41,24 +41,21 @@ tape('lab65 <-> lch65', t => {
 		),
 		{ mode: 'lab65', l: 100, a: 0.20000000000000004, b: 0.2 }
 	);
-	t.end();
 });
 
-tape('color(--lch-d65)', t => {
-	t.deepEqual(lch65('color(--lch-d65 30 0.5 1 / 0.25)'), {
+test('color(--lch-d65)', t => {
+	assert.deepEqual(lch65('color(--lch-d65 30 0.5 1 / 0.25)'), {
 		l: 30,
 		c: 0.5,
 		h: 1,
 		alpha: 0.25,
 		mode: 'lch65'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--lch-d65 30 0.5 1 / 0.25)'),
 		'color(--lch-d65 30 0.5 1 / 0.25)'
 	);
-	t.end();
 });

--- a/test/lchuv.test.js
+++ b/test/lchuv.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { lchuv, rgb, formatCss } from '../src/index.js';
 
-tape('lchuv', t => {
-	t.deepEqual(
+test('lchuv', t => {
+	assert.deepEqual(
 		lchuv('white'),
 		{
 			mode: 'lchuv',
@@ -12,8 +13,8 @@ tape('lchuv', t => {
 		},
 		'white'
 	);
-	t.deepEqual(lchuv('black'), { mode: 'lchuv', l: 0, c: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(lchuv('black'), { mode: 'lchuv', l: 0, c: 0 }, 'black');
+	assert.deepEqual(
 		lchuv('red'),
 		{
 			mode: 'lchuv',
@@ -23,7 +24,7 @@ tape('lchuv', t => {
 		},
 		'red'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		lchuv('#00cc0080'),
 		{
 			mode: 'lchuv',
@@ -34,35 +35,31 @@ tape('lchuv', t => {
 		},
 		'#00cc0080'
 	);
-	t.end();
 });
 
-tape('color(--lchuv)', t => {
-	t.deepEqual(lchuv('color(--lchuv 30 0.5 1 / 0.25)'), {
+test('color(--lchuv)', t => {
+	assert.deepEqual(lchuv('color(--lchuv 30 0.5 1 / 0.25)'), {
 		l: 30,
 		c: 0.5,
 		h: 1,
 		alpha: 0.25,
 		mode: 'lchuv'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--lchuv 30 0.5 1 / 0.25)'),
 		'color(--lchuv 30 0.5 1 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--lchuv none 0.5 none)'), 'lchuv to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--lchuv none 0.5 none)'), 'lchuv to rgb is ok');
+	assert.deepEqual(
 		rgb('color(--lchuv none 0.5 none)'),
 		rgb('color(--lchuv 0 0.5 0)')
 	);
-	t.ok(lchuv('rgb(none 100 20)'), 'rgb to lchuv is ok');
-	t.deepEqual(lchuv('rgb(none 100 20)'), lchuv('rgb(0 100 20)'));
-	t.end();
+	assert.ok(lchuv('rgb(none 100 20)'), 'rgb to lchuv is ok');
+	assert.deepEqual(lchuv('rgb(none 100 20)'), lchuv('rgb(0 100 20)'));
 });

--- a/test/lerp.test.js
+++ b/test/lerp.test.js
@@ -1,14 +1,13 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { lerp, unlerp, trilerp } from '../src/index.js';
 
-tape('lerp()', t => {
-	t.equal(lerp(10, 2, 0.5), 6);
-	t.end();
+test('lerp()', t => {
+	assert.equal(lerp(10, 2, 0.5), 6);
 });
 
-tape('unlerp()', t => {
-	t.equal(unlerp(5, 10, 2.5), -0.5);
-	t.end();
+test('unlerp()', t => {
+	assert.equal(unlerp(5, 10, 2.5), -0.5);
 });
 
 const RYB_CUBE = [
@@ -22,7 +21,7 @@ const RYB_CUBE = [
 	{ mode: 'rgb', r: 0.2, g: 0.094, b: 0 } // black
 ];
 
-tape('trilerp()', t => {
+test('trilerp()', t => {
 	const RYB_COLOR = [1, 0.5, 0.25];
 	const EXPECTED_LINEAR = {
 		mode: 'rgb',
@@ -49,8 +48,6 @@ tape('trilerp()', t => {
 		};
 	}
 
-	t.deepEqual(ryb2rgb(RYB_COLOR, false), EXPECTED_LINEAR, 'ryb: linear');
-	t.deepEqual(ryb2rgb(RYB_COLOR), EXPECTED_BIASED, 'ryb: biased');
-
-	t.end();
+	assert.deepEqual(ryb2rgb(RYB_COLOR, false), EXPECTED_LINEAR, 'ryb: linear');
+	assert.deepEqual(ryb2rgb(RYB_COLOR), EXPECTED_BIASED, 'ryb: biased');
 });

--- a/test/lrgb.test.js
+++ b/test/lrgb.test.js
@@ -1,14 +1,15 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { rgb, lrgb, formatCss } from '../src/index.js';
 
-tape('round-trip', t => {
+test('round-trip', t => {
 	let in_gamut = {
 		mode: 'rgb',
 		r: 0.1,
 		g: 0.25,
 		b: 0.7
 	};
-	t.deepEqual(
+	assert.deepEqual(
 		lrgb(in_gamut),
 		{
 			mode: 'lrgb',
@@ -18,7 +19,7 @@ tape('round-trip', t => {
 		},
 		'in gamut'
 	);
-	t.deepEqual(rgb(lrgb(in_gamut)), in_gamut, 'in gamut');
+	assert.deepEqual(rgb(lrgb(in_gamut)), in_gamut, 'in gamut');
 
 	let out_of_gamut = {
 		mode: 'rgb',
@@ -26,7 +27,7 @@ tape('round-trip', t => {
 		g: 0.25,
 		b: 2.7
 	};
-	t.deepEqual(
+	assert.deepEqual(
 		lrgb(out_of_gamut),
 		{
 			mode: 'lrgb',
@@ -36,43 +37,39 @@ tape('round-trip', t => {
 		},
 		'out of gamut'
 	);
-	t.deepEqual(rgb(lrgb(out_of_gamut)), out_of_gamut, 'out of gamut');
-	t.end();
+	assert.deepEqual(rgb(lrgb(out_of_gamut)), out_of_gamut, 'out of gamut');
 });
 
-tape('color(srgb-linear)', t => {
-	t.deepEqual(lrgb('color(srgb-linear 1 0 0 / 0.25)'), {
+test('color(srgb-linear)', t => {
+	assert.deepEqual(lrgb('color(srgb-linear 1 0 0 / 0.25)'), {
 		r: 1,
 		g: 0,
 		b: 0,
 		alpha: 0.25,
 		mode: 'lrgb'
 	});
-	t.deepEqual(lrgb('color(srgb-linear 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(lrgb('color(srgb-linear 0% 50% 0.5 / 25%)'), {
 		r: 0,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'lrgb'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(srgb-linear 0% 50% 0.5 / 25%)'),
 		'color(srgb-linear 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(srgb-linear none 0.5 none)'), 'lrgb to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(srgb-linear none 0.5 none)'), 'lrgb to rgb is ok');
+	assert.deepEqual(
 		rgb('color(srgb-linear none 0.5 none)'),
 		rgb('color(srgb-linear 0 0.5 0')
 	);
-	t.ok(lrgb('rgb(none 100 20)'), 'rgb to lrgb is ok');
-	t.deepEqual(lrgb('rgb(none 100 20)'), lrgb('rgb(0 100 20)'));
-	t.end();
+	assert.ok(lrgb('rgb(none 100 20)'), 'rgb to lrgb is ok');
+	assert.deepEqual(lrgb('rgb(none 100 20)'), lrgb('rgb(0 100 20)'));
 });

--- a/test/luv.test.js
+++ b/test/luv.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { luv, rgb } from '../src/index.js';
 
-tape('luv', t => {
-	t.deepEqual(
+test('luv', t => {
+	assert.deepEqual(
 		luv('white'),
 		{
 			mode: 'luv',
@@ -12,8 +13,8 @@ tape('luv', t => {
 		},
 		'white'
 	);
-	t.deepEqual(luv('black'), { mode: 'luv', l: 0, u: 0, v: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(luv('black'), { mode: 'luv', l: 0, u: 0, v: 0 }, 'black');
+	assert.deepEqual(
 		luv('red'),
 		{
 			mode: 'luv',
@@ -23,7 +24,7 @@ tape('luv', t => {
 		},
 		'red'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		luv('#00cc0080'),
 		{
 			mode: 'luv',
@@ -34,24 +35,24 @@ tape('luv', t => {
 		},
 		'#00cc0080'
 	);
-	t.end();
 });
 
-tape('color(--luv)', t => {
-	t.deepEqual(luv('color(--luv 30 0.5 1 / 0.25)'), {
+test('color(--luv)', t => {
+	assert.deepEqual(luv('color(--luv 30 0.5 1 / 0.25)'), {
 		l: 30,
 		u: 0.5,
 		v: 1,
 		alpha: 0.25,
 		mode: 'luv'
 	});
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--luv none 0.5 none)'), 'luv to rgb is ok');
-	t.deepEqual(rgb('color(--luv none 0.5 none)'), rgb('color(--luv 0 0.5 0)'));
-	t.ok(luv('rgb(none 100 20)'), 'rgb to luv is ok');
-	t.deepEqual(luv('rgb(none 100 20)'), luv('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('color(--luv none 0.5 none)'), 'luv to rgb is ok');
+	assert.deepEqual(
+		rgb('color(--luv none 0.5 none)'),
+		rgb('color(--luv 0 0.5 0)')
+	);
+	assert.ok(luv('rgb(none 100 20)'), 'rgb to luv is ok');
+	assert.deepEqual(luv('rgb(none 100 20)'), luv('rgb(0 100 20)'));
 });

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	mapper,
 	mapAlphaMultiply,
@@ -9,62 +10,62 @@ import {
 	formatHex8
 } from '../src/index.js';
 
-tape('mapping alpha', t => {
+test('mapping alpha', t => {
 	let multiply = mapper(mapAlphaMultiply);
 	let divide = mapper(mapAlphaDivide);
 
-	t.equal(formatHex8(multiply('#ff00cc80')), '#80006680');
-	t.equal(formatHex8(divide(multiply('#ff00cc80'))), '#ff00cc80');
-	t.end();
+	assert.equal(formatHex8(multiply('#ff00cc80')), '#80006680');
+	assert.equal(formatHex8(divide(multiply('#ff00cc80'))), '#ff00cc80');
 });
 
-tape('linear transfer function', t => {
+test('linear transfer function', t => {
 	let brighten = mapper(mapTransferLinear(2));
-	t.equal(formatHex(brighten('#cc0033')), '#ff0066');
-	t.end();
+	assert.equal(formatHex(brighten('#cc0033')), '#ff0066');
 });
 
-tape('gamma transfer function', t => {
+test('gamma transfer function', t => {
 	let brighten = mapper(mapTransferGamma(2.2));
-	t.equal(formatHex(brighten('#cc0033')), '#ff0070');
-	t.end();
+	assert.equal(formatHex(brighten('#cc0033')), '#ff0070');
 });
 
-tape('mode = null', t => {
+test('mode = null', t => {
 	let increaser = mapper(v => v + 0.1, null);
-	t.equal(formatHex(increaser('#cc0033')), '#e61a4d', 'color is rgb string');
-	t.equal(
+	assert.equal(
+		formatHex(increaser('#cc0033')),
+		'#e61a4d',
+		'color is rgb string'
+	);
+	assert.equal(
 		increaser({ mode: 'rgb', r: 0.8, g: 0, b: 0.2 }).mode,
 		'rgb',
 		'color is rgb'
 	);
-	t.end();
 });
 
-tape('preserve_mode', t => {
+test('preserve_mode', t => {
 	const rgbColor = { mode: 'rgb', r: 0.8, g: 0, b: 0.2 };
 	const fn = v => v + 0.1;
-	t.equal(
+	assert.equal(
 		formatHex(mapper(fn, null, true)(rgbColor)),
 		'#e61a4d',
 		'mode = null, preserve_mode = true'
 	);
-	t.equal(
+	assert.equal(
 		mapper(fn, undefined, true)('#cc0033').mode,
 		'rgb',
 		'mode = undefined, preserve_mode = true'
 	);
-	t.equal(
+	assert.equal(
 		mapper(fn, 'hsl', true)('#cc0033').mode,
 		'rgb',
 		'mode = hsl, preserve_mode = true'
 	);
-	t.equal(
+	assert.equal(
 		mapper(fn, 'hsl', false)('#cc0033').mode,
 		'hsl',
 		'mode = hsl, preserve_mode = false'
 	);
-	t.equal(
+	assert.equal(
 		mapper(fn, 'oklch', false)('#cc0033').mode,
 		'oklch',
 		'mode = oklch, preserve_mode = false'
@@ -76,15 +77,14 @@ tape('preserve_mode', t => {
 		c: 0.5,
 		h: 1
 	};
-	t.equal(
+	assert.equal(
 		mapper(fn, 'hsl', false)(oklchColor).mode,
 		'hsl',
 		'oklch color, mode = hsl, preserve_mode = false'
 	);
-	t.equal(
+	assert.equal(
 		mapper(fn, 'hsl', true)(oklchColor).mode,
 		'oklch',
 		'oklch color, mode = hsl, preserve_mode = true'
 	);
-	t.end();
 });

--- a/test/nearest.test.js
+++ b/test/nearest.test.js
@@ -1,16 +1,17 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { nearest, colorsNamed } from '../src/index.js';
 
 let nearestNamedColor = nearest(Object.keys(colorsNamed));
 
-tape('check against named colors', test => {
-	test.deepEqual(
+test('check against named colors', test => {
+	assert.deepEqual(
 		nearestNamedColor('red'),
 		['red'],
 		'Closest named color to red'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		nearestNamedColor('red', Infinity, 0.5),
 		[
 			'red',
@@ -25,11 +26,9 @@ tape('check against named colors', test => {
 		],
 		'Close named colors to red, d <= 0.5'
 	);
-
-	test.end();
 });
 
-tape('nearest() with accessor', t => {
+test('nearest() with accessor', t => {
 	let palette = {
 		Burgundy: '#914e72',
 		Blue: '#0078bf',
@@ -39,6 +38,5 @@ tape('nearest() with accessor', t => {
 	};
 	let names = Object.keys(palette);
 	let nearestColors = nearest(names, undefined, name => palette[name]);
-	t.deepEqual(nearestColors('red', 1), ['Bright Red']);
-	t.end();
+	assert.deepEqual(nearestColors('red', 1), ['Bright Red']);
 });

--- a/test/none.test.js
+++ b/test/none.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	parse,
 	formatHex,
@@ -8,95 +9,108 @@ import {
 	formatCss
 } from '../src/index.js';
 
-tape('parse "none" keyword', t => {
-	t.deepEqual(
+test('parse "none" keyword', t => {
+	assert.deepEqual(
 		parse('rgb(none, 255, 127.5)'),
 		undefined,
 		'rgb() <number> (legacy)'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		parse('rgb(none 255 127.5 / none)'),
 		{ mode: 'rgb', g: 1, b: 0.5 },
 		'rgb() <number>'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		parse('rgb(none, 100%, 50%)'),
 		undefined,
 		'rgb() <percentage> (legacy)'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		parse('rgba(none 100% 50% / none)'),
 		{ mode: 'rgb', g: 1, b: 0.5 },
 		'rgb() <percentage>'
 	);
-	t.deepEqual(parse('hsl(none, 50%, 100%)'), undefined, 'hsl() (legacy)');
-	t.deepEqual(parse('hsla(none 50% none)'), { mode: 'hsl', s: 0.5 }, 'hsl()');
+	assert.deepEqual(
+		parse('hsl(none, 50%, 100%)'),
+		undefined,
+		'hsl() (legacy)'
+	);
+	assert.deepEqual(
+		parse('hsla(none 50% none)'),
+		{ mode: 'hsl', s: 0.5 },
+		'hsl()'
+	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		parse('hwb(none none 50% / none)'),
 		{ mode: 'hwb', b: 0.5 },
 		'hwb()'
 	);
 
-	t.deepEqual(parse('lab(none 12 none)'), { mode: 'lab', a: 12 }, 'lab()');
+	assert.deepEqual(
+		parse('lab(none 12 none)'),
+		{ mode: 'lab', a: 12 },
+		'lab()'
+	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		parse('lch(5% none 1turn)'),
 		{ mode: 'lch', l: 5, h: 360 },
 		'lch()'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		parse('color(display-p3 none none none / 0.1)'),
 		{ mode: 'p3', alpha: 0.1 },
 		'color()'
 	);
-
-	t.end();
 });
 
-tape('serialize "none" keyword', t => {
-	t.equal(
+test('serialize "none" keyword', t => {
+	assert.equal(
 		formatRgb('rgb(none none none / none)'),
 		'rgb(0, 0, 0)',
 		'formatRgb'
 	);
-	t.equal(formatHex('rgb(none none none / none)'), '#000000', 'formatHex');
-	t.equal(
+	assert.equal(
+		formatHex('rgb(none none none / none)'),
+		'#000000',
+		'formatHex'
+	);
+	assert.equal(
 		formatHex8('rgb(none none none / none)'),
 		'#000000ff',
 		'formatHex8'
 	);
-	t.equal(
+	assert.equal(
 		formatHsl('hsl(none none none / none)'),
 		'hsl(0, 0%, 0%)',
 		'formatHsl'
 	);
-	t.equal(
+	assert.equal(
 		formatCss('hsl(none none none)'),
 		'hsl(none none none)',
 		'formatCss(hsl)'
 	);
-	t.equal(
+	assert.equal(
 		formatCss('lab(none none none / none)'),
 		'lab(none none none)',
 		'formatCss(lab)'
 	);
-	t.equal(
+	assert.equal(
 		formatCss('lch(none none none / none)'),
 		'lch(none none none)',
 		'formatCss(lch)'
 	);
 
-	t.equal(
+	assert.equal(
 		formatCss('oklab(none none none / none)'),
 		'oklab(none none none)',
 		'formatCss(oklab)'
 	);
-	t.equal(
+	assert.equal(
 		formatCss('oklch(none none none / none)'),
 		'oklch(none none none)',
 		'formatCss(oklch)'
 	);
-	t.end();
 });

--- a/test/normalizePositions.test.js
+++ b/test/normalizePositions.test.js
@@ -1,16 +1,15 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import normalize from '../src/util/normalizePositions.js';
 
-tape('util: normalizePositions', t => {
-	t.deepEqual(
+test('util: normalizePositions', t => {
+	assert.deepEqual(
 		normalize([undefined, undefined, undefined, undefined, undefined]),
 		[0, 0.25, 0.5, 0.75, 1]
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		normalize([0.2, undefined, undefined, 0.8]),
 		[0.2, 0.4, 0.6000000000000001, 0.8]
 	);
-
-	t.end();
 });

--- a/test/okhsl.test.js
+++ b/test/okhsl.test.js
@@ -1,73 +1,70 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { okhsl, rgb, formatHex, formatCss } from '../src/index.js';
 
-tape('rgb → okhsl', t => {
-	t.equal(
+test('rgb → okhsl', t => {
+	assert.equal(
 		formatCss(okhsl('red')),
 		'color(--okhsl 29.2338851923426 1.0000000001434 0.5680846525040861)',
 		'red'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(okhsl('white')),
 		'color(--okhsl none 0 0.9999999923961895)',
 		'white'
 	);
-	t.equal(formatCss(okhsl('black')), 'color(--okhsl none 0 0)', 'black');
-	t.equal(
+	assert.equal(formatCss(okhsl('black')), 'color(--okhsl none 0 0)', 'black');
+	assert.equal(
 		formatCss(okhsl('#3333')),
 		'color(--okhsl none 0 0.2209950715093747 / 0.2)',
 		'#333'
 	);
-	t.end();
 });
 
-tape('okhsl → rgb', t => {
-	t.equal(
+test('okhsl → rgb', t => {
+	assert.equal(
 		formatHex(
 			'color(--okhsl 29.233885192342633 1.0000000001433997 0.5680846525040862)'
 		),
 		'#ff0000',
 		'red'
 	);
-	t.equal(
+	assert.equal(
 		formatHex('color(--okhsl 0 0 0.9999999923961898)'),
 		'#ffffff',
 		'white'
 	);
-	t.equal(formatHex('color(--okhsl 0 0 0)'), '#000000', 'black');
-	t.equal(
+	assert.equal(formatHex('color(--okhsl 0 0 0)'), '#000000', 'black');
+	assert.equal(
 		formatHex('color(--okhsl 0 0 0.2209950715093747 / 0.2)'),
 		'#333333',
 		'#333'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		formatHex('color(--okhsl 0 1 1)'),
 		'#ffffff',
 		'color(--okhsl 0 1 1)'
 	);
-	t.equal(
+	assert.equal(
 		formatHex('color(--okhsl 0 1 0)'),
 		'#000000',
 		'color(--okhsl 0 1 0)'
 	);
-	t.end();
 });
 
-tape('rgb → okhsl → rgb', t => {
-	t.equal(formatHex(okhsl('red')), '#ff0000', 'red');
-	t.equal(formatHex(okhsl('white')), '#ffffff', 'white');
-	t.equal(formatHex(okhsl('black')), '#000000', 'black');
-	t.equal(formatHex(okhsl('#3333')), '#333333', '#333');
-	t.end();
+test('rgb → okhsl → rgb', t => {
+	assert.equal(formatHex(okhsl('red')), '#ff0000', 'red');
+	assert.equal(formatHex(okhsl('white')), '#ffffff', 'white');
+	assert.equal(formatHex(okhsl('black')), '#000000', 'black');
+	assert.equal(formatHex(okhsl('#3333')), '#333333', '#333');
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--okhsl none 0.5 none)'));
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--okhsl none 0.5 none)'));
+	assert.deepEqual(
 		rgb('color(--okhsl none 0.5 none)'),
 		rgb('color(--okhsl 0 0.5 0)')
 	);
-	t.ok(okhsl('rgb(none 100 20)'));
-	t.deepEqual(okhsl('rgb(none 100 20)'), okhsl('rgb(0 100 20)'));
-	t.end();
+	assert.ok(okhsl('rgb(none 100 20)'));
+	assert.deepEqual(okhsl('rgb(none 100 20)'), okhsl('rgb(0 100 20)'));
 });

--- a/test/okhsv.test.js
+++ b/test/okhsv.test.js
@@ -1,73 +1,70 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { okhsv, rgb, formatHex, formatCss } from '../src/index.js';
 
-tape('rgb → okhsv', t => {
-	t.equal(
+test('rgb → okhsv', t => {
+	assert.equal(
 		formatCss(okhsv('red')),
 		'color(--okhsv 29.2338851923426 0.9995219692256307 0.9999999999999997)',
 		'red'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(okhsv('white')),
 		'color(--okhsv none 0 1.00000009386827)',
 		'white'
 	);
-	t.equal(formatCss(okhsv('black')), 'color(--okhsv none 0 0)', 'black');
-	t.equal(
+	assert.equal(formatCss(okhsv('black')), 'color(--okhsv none 0 0)', 'black');
+	assert.equal(
 		formatCss(okhsv('#3333')),
 		'color(--okhsv none 0 0.220995101721347 / 0.2)',
 		'#333'
 	);
-	t.end();
 });
 
-tape('okhsv → rgb', t => {
-	t.equal(
+test('okhsv → rgb', t => {
+	assert.equal(
 		formatHex(
 			'color(--okhsv 29.233885192342633 0.9995219692256989 1.0000000001685625)'
 		),
 		'#ff0000',
 		'red'
 	);
-	t.equal(
+	assert.equal(
 		formatHex('color(--okhsv 0 0 0.9999999923961898)'),
 		'#ffffff',
 		'white'
 	);
-	t.equal(formatHex('color(--okhsv 0 0 0)'), '#000000', 'black');
-	t.equal(
+	assert.equal(formatHex('color(--okhsv 0 0 0)'), '#000000', 'black');
+	assert.equal(
 		formatHex('color(--okhsv 0 0 0.2209950715093747 / 0.2)'),
 		'#333333',
 		'#333'
 	);
-	t.equal(
+	assert.equal(
 		formatHex('color(--okhsv 0 1 1)'),
 		'#ff0088',
 		'color(--okhsv 0 1 1)'
 	);
-	t.equal(
+	assert.equal(
 		formatHex('color(--okhsv 0 1 0)'),
 		'#000000',
 		'color(--okhsv 0 1 0)'
 	);
-	t.end();
 });
 
-tape('rgb → okhsv → rgb', t => {
-	t.equal(formatHex(okhsv('red')), '#ff0000', 'red');
-	t.equal(formatHex(okhsv('white')), '#ffffff', 'white');
-	t.equal(formatHex(okhsv('black')), '#000000', 'black');
-	t.equal(formatHex(okhsv('#3333')), '#333333', '#333');
-	t.end();
+test('rgb → okhsv → rgb', t => {
+	assert.equal(formatHex(okhsv('red')), '#ff0000', 'red');
+	assert.equal(formatHex(okhsv('white')), '#ffffff', 'white');
+	assert.equal(formatHex(okhsv('black')), '#000000', 'black');
+	assert.equal(formatHex(okhsv('#3333')), '#333333', '#333');
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--okhsv none 0.5 none)'));
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(--okhsv none 0.5 none)'));
+	assert.deepEqual(
 		rgb('color(--okhsv none 0.5 none)'),
 		rgb('color(--okhsv 0 0.5 0)')
 	);
-	t.ok(okhsv('rgb(none 100 20)'));
-	t.deepEqual(okhsv('rgb(none 100 20)'), okhsv('rgb(0 100 20)'));
-	t.end();
+	assert.ok(okhsv('rgb(none 100 20)'));
+	assert.deepEqual(okhsv('rgb(none 100 20)'), okhsv('rgb(0 100 20)'));
 });

--- a/test/oklab.test.js
+++ b/test/oklab.test.js
@@ -1,4 +1,5 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import {
 	oklab,
 	rgb,
@@ -7,22 +8,26 @@ import {
 	removeParser
 } from '../src/index.js';
 
-tape('rgb → oklab', t => {
-	t.deepEqual(
+test('rgb → oklab', t => {
+	assert.deepEqual(
 		oklab('white'),
 		{ mode: 'oklab', l: 0.999999993473546, a: 0, b: 0 },
 		'white'
 	);
 
 	// Tests that achromatic RGB colors get a = b = 0 in OKLab
-	t.deepEqual(
+	assert.deepEqual(
 		oklab('#111'),
 		{ mode: 'oklab', l: 0.1776377719172259, a: 0, b: 0 },
 		'#111'
 	);
 
-	t.deepEqual(oklab('black'), { mode: 'oklab', l: 0, a: 0, b: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(
+		oklab('black'),
+		{ mode: 'oklab', l: 0, a: 0, b: 0 },
+		'black'
+	);
+	assert.deepEqual(
 		oklab('red'),
 		{
 			mode: 'oklab',
@@ -32,10 +37,9 @@ tape('rgb → oklab', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(--oklab) with custom ident registration', t => {
+test('color(--oklab) with custom ident registration', t => {
 	const c = 'color(--oklab 30 0.5 1 / 0.25)';
 	const cc = {
 		l: 30,
@@ -44,63 +48,62 @@ tape('color(--oklab) with custom ident registration', t => {
 		alpha: 0.25,
 		mode: 'oklab'
 	};
-	t.equal(oklab(c), undefined);
+	assert.equal(oklab(c), undefined);
 	useParser('--oklab', 'oklab');
-	t.deepEqual(oklab(c), cc);
+	assert.deepEqual(oklab(c), cc);
 	removeParser('--oklab');
-	t.equal(oklab(c), undefined);
-	t.end();
+	assert.equal(oklab(c), undefined);
 });
 
-tape('oklab()', t => {
-	t.deepEqual(oklab('oklab(0.4 0.5 1 / 0.25)'), {
+test('oklab()', t => {
+	assert.deepEqual(oklab('oklab(0.4 0.5 1 / 0.25)'), {
 		l: 0.4,
 		a: 0.5,
 		b: 1,
 		alpha: 0.25,
 		mode: 'oklab'
 	});
-	t.deepEqual(oklab('oklab(25% -20% 125% / 15%)'), {
+	assert.deepEqual(oklab('oklab(25% -20% 125% / 15%)'), {
 		mode: 'oklab',
 		l: 0.25,
 		a: -0.08,
 		b: 0.5,
 		alpha: 0.15
 	});
-	t.deepEqual(
+	assert.deepEqual(
 		oklab('oklab(-0.5 1 0)'),
 		{ l: 0, a: 1, b: 0, mode: 'oklab' },
 		'clamp L to 0'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		oklab('oklab(2 1 0)'),
 		{ l: 1, a: 1, b: 0, mode: 'oklab' },
 		'clamp L to 1'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		oklab('oklab(0.4 -1 1 / -0.5)'),
 		{ mode: 'oklab', l: 0.4, a: -1, b: 1, alpha: 0 },
 		'clamp alpha < 0'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		oklab('oklab(0.4 -1 1 / 1.5)'),
 		{ mode: 'oklab', l: 0.4, a: -1, b: 1, alpha: 1 },
 		'clamp alpha > 1'
 	);
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(formatCss('oklab(30% 0.5 1 / 0.25)'), 'oklab(0.3 0.5 1 / 0.25)');
-	t.end();
+test('formatCss', t => {
+	assert.equal(
+		formatCss('oklab(30% 0.5 1 / 0.25)'),
+		'oklab(0.3 0.5 1 / 0.25)'
+	);
 });
 
-tape('missing components', t => {
-	t.ok(rgb('oklab(none 0.5 none)'), 'oklab to rgb is ok');
-	t.deepEqual(rgb('oklab(none 0.5 none)'), rgb('oklab(0% 0.5 0%)'));
-	t.ok(oklab('rgb(none 100 20)'), 'rgb to oklab is ok');
-	t.deepEqual(oklab('rgb(none 100 20)'), oklab('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('oklab(none 0.5 none)'), 'oklab to rgb is ok');
+	assert.deepEqual(rgb('oklab(none 0.5 none)'), rgb('oklab(0% 0.5 0%)'));
+	assert.ok(oklab('rgb(none 100 20)'), 'rgb to oklab is ok');
+	assert.deepEqual(oklab('rgb(none 100 20)'), oklab('rgb(0 100 20)'));
 });

--- a/test/oklch.test.js
+++ b/test/oklch.test.js
@@ -1,19 +1,20 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { oklch, formatCss, useParser, removeParser } from '../src/index.js';
 
-tape('oklch', t => {
-	t.deepEqual(
+test('oklch', t => {
+	assert.deepEqual(
 		oklch('white'),
 		{ mode: 'oklch', l: 0.999999993473546, c: 0 },
 		'white'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		oklch('#111'),
 		{ mode: 'oklch', l: 0.1776377719172259, c: 0 },
 		'#111'
 	);
-	t.deepEqual(oklch('black'), { mode: 'oklch', l: 0, c: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(oklch('black'), { mode: 'oklch', l: 0, c: 0 }, 'black');
+	assert.deepEqual(
 		oklch('red'),
 		{
 			mode: 'oklch',
@@ -23,25 +24,24 @@ tape('oklch', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('oklch()', t => {
-	t.deepEqual(oklch('oklch(0.3 0.5 1 / 0.25)'), {
+test('oklch()', t => {
+	assert.deepEqual(oklch('oklch(0.3 0.5 1 / 0.25)'), {
 		l: 0.3,
 		c: 0.5,
 		h: 1,
 		alpha: 0.25,
 		mode: 'oklch'
 	});
-	t.deepEqual(oklch('oklch(40% 50% .5turn / 15%)'), {
+	assert.deepEqual(oklch('oklch(40% 50% .5turn / 15%)'), {
 		mode: 'oklch',
 		l: 0.4,
 		c: 0.2,
 		h: 180,
 		alpha: 0.15
 	});
-	t.deepEqual(
+	assert.deepEqual(
 		oklch('oklch(-1 0.5 0.5turn / 0.42)'),
 		{
 			mode: 'oklch',
@@ -52,7 +52,7 @@ tape('oklch()', t => {
 		},
 		'clamp L to 0'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		oklch('oklch(2 0.5 40deg / 0.42)'),
 		{
 			mode: 'oklch',
@@ -63,21 +63,20 @@ tape('oklch()', t => {
 		},
 		'clamp L to 1'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		oklch('oklch(0.4 0.5 10 / -0.5)'),
 		{ mode: 'oklch', l: 0.4, c: 0.5, h: 10, alpha: 0 },
 		'clamp alpha < 0'
 	);
 
-	t.deepEqual(
+	assert.deepEqual(
 		oklch('oklch(0.4 0.5 10 / 1.5)'),
 		{ mode: 'oklch', l: 0.4, c: 0.5, h: 10, alpha: 1 },
 		'clamp alpha > 1'
 	);
-	t.end();
 });
 
-tape('color(--oklch) with custom ident', t => {
+test('color(--oklch) with custom ident', t => {
 	const color_str = 'color(--oklch 30 0.5 1 / 0.25)';
 	const color = {
 		l: 30,
@@ -86,19 +85,20 @@ tape('color(--oklch) with custom ident', t => {
 		alpha: 0.25,
 		mode: 'oklch'
 	};
-	t.equal(oklch(color_str), undefined);
+	assert.equal(oklch(color_str), undefined);
 	useParser('--oklch', 'oklch');
-	t.deepEqual(oklch(color_str), color);
+	assert.deepEqual(oklch(color_str), color);
 	removeParser('--oklch');
-	t.equal(oklch(color_str), undefined);
-	t.end();
+	assert.equal(oklch(color_str), undefined);
 });
 
-tape('formatCss', t => {
-	t.equal(formatCss('oklch(30% 0.5 1 / 0.25)'), 'oklch(0.3 0.5 1 / 0.25)');
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
+		formatCss('oklch(30% 0.5 1 / 0.25)'),
+		'oklch(0.3 0.5 1 / 0.25)'
+	);
+	assert.equal(
 		formatCss(oklch('#ffffff00')),
 		'oklch(0.999999993473546 0 none / 0)'
 	);
-	t.end();
 });

--- a/test/p3.test.js
+++ b/test/p3.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { p3, rgb, formatCss } from '../src/index.js';
 
-tape('p3', t => {
-	t.deepEqual(
+test('p3', t => {
+	assert.deepEqual(
 		p3('white'),
 		{
 			mode: 'p3',
@@ -12,8 +13,8 @@ tape('p3', t => {
 		},
 		'white'
 	);
-	t.deepEqual(p3('black'), { mode: 'p3', r: 0, g: 0, b: 0 }, 'black');
-	t.deepEqual(
+	assert.deepEqual(p3('black'), { mode: 'p3', r: 0, g: 0, b: 0 }, 'black');
+	assert.deepEqual(
 		p3('red'),
 		{
 			mode: 'p3',
@@ -23,42 +24,38 @@ tape('p3', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(display-p3)', t => {
-	t.deepEqual(p3('color(display-p3 1 0 0 / 0.25)'), {
+test('color(display-p3)', t => {
+	assert.deepEqual(p3('color(display-p3 1 0 0 / 0.25)'), {
 		r: 1,
 		g: 0,
 		b: 0,
 		alpha: 0.25,
 		mode: 'p3'
 	});
-	t.deepEqual(p3('color(display-p3 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(p3('color(display-p3 0% 50% 0.5 / 25%)'), {
 		r: 0,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'p3'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(display-p3 0% 50% 0.5 / 25%)'),
 		'color(display-p3 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(display-p3 none 0.5 none)'), 'p3 to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(display-p3 none 0.5 none)'), 'p3 to rgb is ok');
+	assert.deepEqual(
 		rgb('color(display-p3 none 0.5 none)'),
 		rgb('color(display-p3 0 0.5 0')
 	);
-	t.ok(p3('rgb(none 100 20)'), 'rgb to p3 is ok');
-	t.deepEqual(p3('rgb(none 100 20)'), p3('rgb(0 100 20)'));
-	t.end();
+	assert.ok(p3('rgb(none 100 20)'), 'rgb to p3 is ok');
+	assert.deepEqual(p3('rgb(none 100 20)'), p3('rgb(0 100 20)'));
 });

--- a/test/parse.test.js
+++ b/test/parse.test.js
@@ -1,14 +1,15 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { parse } from '../src/index.js';
 
-tape('named colors', function (test) {
-	test.deepEqual(
+test('named colors', t => {
+	assert.deepEqual(
 		parse('tomato'),
 		{ mode: 'rgb', r: 1, g: 0.38823529411764707, b: 0.2784313725490196 },
 		'tomato'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('RoyalBlue'),
 		{
 			mode: 'rgb',
@@ -18,36 +19,34 @@ tape('named colors', function (test) {
 		},
 		'RoyalBlue (CamelCase)'
 	);
-
-	test.end();
 });
 
-tape('hex colors', function (test) {
-	test.deepEqual(
+test('hex colors', t => {
+	assert.deepEqual(
 		parse('#369'),
 		{ mode: 'rgb', r: 0.2, g: 0.4, b: 0.6 },
 		'#369'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('369'),
 		{ mode: 'rgb', r: 0.2, g: 0.4, b: 0.6 },
 		'369'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('#3690'),
 		{ mode: 'rgb', r: 0.2, g: 0.4, b: 0.6, alpha: 0 },
 		'#3690'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('3690'),
 		{ mode: 'rgb', r: 0.2, g: 0.4, b: 0.6, alpha: 0 },
 		'3690'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('#163264'),
 		{
 			mode: 'rgb',
@@ -58,7 +57,7 @@ tape('hex colors', function (test) {
 		'#163264'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('163264'),
 		{
 			mode: 'rgb',
@@ -69,7 +68,7 @@ tape('hex colors', function (test) {
 		'163264'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('#163264ff'),
 		{
 			mode: 'rgb',
@@ -81,7 +80,7 @@ tape('hex colors', function (test) {
 		'#163264ff'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('163264FF'),
 		{
 			mode: 'rgb',
@@ -92,206 +91,200 @@ tape('hex colors', function (test) {
 		},
 		'163264FF'
 	);
-
-	test.end();
 });
 
-tape('rgb', function (test) {
-	test.deepEqual(
+test('rgb', t => {
+	assert.deepEqual(
 		parse('rgb(255, 0, 0)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgb legacy'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgb(100%, 0%, 0%)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgb legacy (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgba(255, 0, 0, 0.5)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb', alpha: 0.5 },
 		'rgba legacy'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgba(100%, 0%, 0%, 50%)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb', alpha: 0.5 },
 		'rgba legacy (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgb(255  0  0)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgb current'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgb(100% 0%   0%)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgb current (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgb(255 0  0 / 0.5)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb', alpha: 0.5 },
 		'rgba current'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgb(100% 0% 0% / 50%)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb', alpha: 0.5 },
 		'rgba current (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgba(255, 0, 0, 150%)'),
 		{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 1 },
 		'rgb legacy, clamp alpha > 1'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgba(255, 0, 0, -50%)'),
 		{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 0 },
 		'rgb legacy, clamp alpha < 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgb(255 0 0 / 150%)'),
 		{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 1 },
 		'rgb modern, clamp alpha > 1'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('rgb(255 0 0 / -50%)'),
 		{ mode: 'rgb', r: 1, g: 0, b: 0, alpha: 0 },
 		'rgb modern, clamp alpha < 0'
 	);
-
-	test.end();
 });
 
-tape('hsl', function (test) {
-	test.deepEqual(
+test('hsl', t => {
+	assert.deepEqual(
 		parse('hsl(0, 1, 0.5)'),
 		undefined,
 		'hsl legacy (no percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(120, 100%, 50%)'),
 		{ h: 120, s: 1, l: 0.5, mode: 'hsl' },
 		'hsl legacy (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(120deg, 100%, 50%)'),
 		{ h: 120, s: 1, l: 0.5, mode: 'hsl' },
 		'hsl legacy (deg)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(0.5turn, 100%, 50%)'),
 		{ h: 180, s: 1, l: 0.5, mode: 'hsl' },
 		'hsl legacy (turn)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse(`hsl(${Math.PI}rad, 100%, 50%)`),
 		{ h: 180, s: 1, l: 0.5, mode: 'hsl' },
 		'hsl legacy (rad)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(40grad, 100%, 50%)'),
 		{ h: 36, s: 1, l: 0.5, mode: 'hsl' },
 		'hsl legacy (grad)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsla(0, 1, 0.5, 0.5)'),
 		undefined,
 		'hsla legacy (no percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsla(240, 100%, 50%, 50%)'),
 		{ h: 240, s: 1, l: 0.5, mode: 'hsl', alpha: 0.5 },
 		'hsla legacy (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(0 100 50)'),
 		{ h: 0, s: 1, l: 0.5, mode: 'hsl' },
 		'hsl current (no percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(180 100% 50%)'),
 		{ h: 180, s: 1, l: 0.5, mode: 'hsl' },
 		'hsl current (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(0 100 50 / 0.5)'),
 		{ h: 0, s: 1, l: 0.5, mode: 'hsl', alpha: 0.5 },
 		'hsla current (no percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(0 100% 50% / 50%)'),
 		{ h: 0, s: 1, l: 0.5, mode: 'hsl', alpha: 0.5 },
 		'hsla current (percentage)'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsla(240, 100%, 50%, -50%)'),
 		{ mode: 'hsl', h: 240, s: 1, l: 0.5, alpha: 0 },
 		'hsl legacy, clamp alpha < 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsla(240, 100%, 50%, 150%)'),
 		{ mode: 'hsl', h: 240, s: 1, l: 0.5, alpha: 1 },
 		'hsl legacy, clamp alpha > 1'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsl(240 100% 50% / -50%)'),
 		{ mode: 'hsl', h: 240, s: 1, l: 0.5, alpha: 0 },
 		'hsl modern, clamp alpha < 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hsla(240 100% 50% / 150%)'),
 		{ mode: 'hsl', h: 240, s: 1, l: 0.5, alpha: 1 },
 		'hsl modern, clamp alpha > 1'
 	);
-
-	test.end();
 });
 
-tape('hwb', function (test) {
-	test.deepEqual(
+test('hwb', t => {
+	assert.deepEqual(
 		parse('hwb(100 0% 0%)'),
 		{ h: 100, w: 0, b: 0, mode: 'hwb' },
 		'black'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hwb(200 150% 150%)'),
 		{ h: 200, w: 1.5, b: 1.5, mode: 'hwb' },
 		'grey'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hwb(200 10% 30% / 50%)'),
 		{ h: 200, w: 0.1, b: 0.3, alpha: 0.5, mode: 'hwb' },
 		'hwba'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hwb(60deg 25 100 / 0.5)'),
 		{
 			h: 60,
@@ -303,125 +296,115 @@ tape('hwb', function (test) {
 		'<number>'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hwb(50deg 25 100 / -0.5)'),
 		{ mode: 'hwb', h: 50, w: 0.25, b: 1, alpha: 0 },
 		'clamp alpha < 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('hwb(50deg 25 100 / 150%)'),
 		{ mode: 'hwb', h: 50, w: 0.25, b: 1, alpha: 1 },
 		'clamp alpha > 1'
 	);
-
-	test.end();
 });
 
-tape('transparent', function (test) {
-	test.deepEqual(parse('transparent'), {
+test('transparent', t => {
+	assert.deepEqual(parse('transparent'), {
 		r: 0,
 		g: 0,
 		b: 0,
 		alpha: 0,
 		mode: 'rgb'
 	});
-
-	test.end();
 });
 
-tape('lab()', function (test) {
-	test.deepEqual(
+test('lab()', t => {
+	assert.deepEqual(
 		parse('lab(50% -5 10 / 50%)'),
 		{ l: 50, a: -5, b: 10, alpha: 0.5, mode: 'lab' },
 		'lab + alpha'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lab(50% -5 10)'),
 		{ l: 50, a: -5, b: 10, mode: 'lab' },
 		'lab with percentage'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lab(130 -45 +1000)'),
 		{ l: 100, a: -45, b: 1000, mode: 'lab' },
 		'clamp L to 100'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lab(-1 -45 +1000)'),
 		{ l: 0, a: -45, b: 1000, mode: 'lab' },
 		'clamp L to 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lab(40 -10 10 / -0.5)'),
 		{ mode: 'lab', l: 40, a: -10, b: 10, alpha: 0 },
 		'clamp alpha < 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lab(40 -10 10 / 1.5)'),
 		{ mode: 'lab', l: 40, a: -10, b: 10, alpha: 1 },
 		'clamp alpha > 1'
 	);
-
-	test.end();
 });
 
-tape('lch()', function (test) {
-	test.deepEqual(
+test('lch()', t => {
+	assert.deepEqual(
 		parse('lch(50% 3 240 / 50%)'),
 		{ l: 50, c: 3, h: 240, alpha: 0.5, mode: 'lch' },
 		'lch + alpha'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lch(50% -3 240deg / 50%)'),
 		{ l: 50, c: 0, h: 240, alpha: 0.5, mode: 'lch' },
 		'lch negative c'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lch(50% 3 240)'),
 		{ l: 50, c: 3, h: 240, mode: 'lch' },
 		'lch with percentage'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lch(130 -45 480deg)'),
 		{ l: 100, c: 0, h: 480, mode: 'lch' },
 		'clamp L to 100, C to 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lch(-1 -45 -480deg)'),
 		{ l: 0, c: 0, h: -480, mode: 'lch' },
 		'clamp L to 0, C to 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lch(40 5 10 / -0.5)'),
 		{ mode: 'lch', l: 40, c: 5, h: 10, alpha: 0 },
 		'clamp alpha < 0'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		parse('lch(40 5 10 / 1.5)'),
 		{ mode: 'lch', l: 40, c: 5, h: 10, alpha: 1 },
 		'clamp alpha > 1'
 	);
-
-	test.end();
 });
 
-tape('undefined', function (test) {
-	test.equal(parse(undefined), undefined);
-	test.end();
+test('undefined', t => {
+	assert.equal(parse(undefined), undefined);
 });
 
-tape('Issue #204', function (test) {
-	test.equal(parse('oklch(70% 0..1 156)'), undefined);
-	test.end();
+test('Issue #204', t => {
+	assert.equal(parse('oklch(70% 0..1 156)'), undefined);
 });

--- a/test/prophoto.test.js
+++ b/test/prophoto.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { prophoto, rgb, formatCss } from '../src/index.js';
 
-tape('prophoto', t => {
-	t.deepEqual(
+test('prophoto', t => {
+	assert.deepEqual(
 		prophoto('white'),
 		{
 			mode: 'prophoto',
@@ -12,12 +13,12 @@ tape('prophoto', t => {
 		},
 		'white'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		prophoto('black'),
 		{ mode: 'prophoto', r: 0, g: 0, b: 0 },
 		'black'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		prophoto('red'),
 		{
 			mode: 'prophoto',
@@ -27,42 +28,41 @@ tape('prophoto', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(prophoto-rgb)', t => {
-	t.deepEqual(prophoto('color(prophoto-rgb 1 0 0 / 0.25)'), {
+test('color(prophoto-rgb)', t => {
+	assert.deepEqual(prophoto('color(prophoto-rgb 1 0 0 / 0.25)'), {
 		r: 1,
 		g: 0,
 		b: 0,
 		alpha: 0.25,
 		mode: 'prophoto'
 	});
-	t.deepEqual(prophoto('color(prophoto-rgb 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(prophoto('color(prophoto-rgb 0% 50% 0.5 / 25%)'), {
 		r: 0,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'prophoto'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(prophoto-rgb 0% 50% 0.5 / 25%)'),
 		'color(prophoto-rgb 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(prophoto-rgb none 0.5 none)'), 'prophoto to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(
+		rgb('color(prophoto-rgb none 0.5 none)'),
+		'prophoto to rgb is ok'
+	);
+	assert.deepEqual(
 		rgb('color(prophoto-rgb none 0.5 none)'),
 		rgb('color(prophoto-rgb 0 0.5 0')
 	);
-	t.ok(prophoto('rgb(none 100 20)'), 'rgb to prophoto is ok');
-	t.deepEqual(prophoto('rgb(none 100 20)'), prophoto('rgb(0 100 20)'));
-	t.end();
+	assert.ok(prophoto('rgb(none 100 20)'), 'rgb to prophoto is ok');
+	assert.deepEqual(prophoto('rgb(none 100 20)'), prophoto('rgb(0 100 20)'));
 });

--- a/test/random.test.js
+++ b/test/random.test.js
@@ -1,24 +1,22 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { random } from '../src/index.js';
 
-tape('random (rgb)', test => {
+test('random (rgb)', test => {
 	let c1 = random();
 	let c2 = random('rgb', { r: 0.1 });
 	let c3 = random('rgb', { r: [0.4, 0.6] });
 
-	test.equal(c1.mode, 'rgb');
-	test.ok(c1.r >= 0);
-	test.ok(c1.r <= 1);
+	assert.equal(c1.mode, 'rgb');
+	assert.ok(c1.r >= 0);
+	assert.ok(c1.r <= 1);
 
-	test.equal(c2.r, 0.1);
-	test.ok(c3.r >= 0.4);
-	test.ok(c3.r <= 0.6);
-
-	test.end();
+	assert.equal(c2.r, 0.1);
+	assert.ok(c3.r >= 0.4);
+	assert.ok(c3.r <= 0.6);
 });
 
-tape('random (lch)', test => {
+test('random (lch)', test => {
 	let c = random('lch');
-	test.equal(c.mode, 'lch');
-	test.end();
+	assert.equal(c.mode, 'lch');
 });

--- a/test/rec2020.test.js
+++ b/test/rec2020.test.js
@@ -1,18 +1,19 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { rec2020, rgb, formatCss } from '../src/index.js';
 
-tape('rec2020', t => {
-	t.deepEqual(
+test('rec2020', t => {
+	assert.deepEqual(
 		rec2020('white'),
 		{ mode: 'rec2020', r: 1, g: 1, b: 1 },
 		'white'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		rec2020('black'),
 		{ mode: 'rec2020', r: 0, g: 0, b: 0 },
 		'black'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		rec2020('red'),
 		{
 			mode: 'rec2020',
@@ -22,42 +23,38 @@ tape('rec2020', t => {
 		},
 		'red'
 	);
-	t.end();
 });
 
-tape('color(rec2020)', t => {
-	t.deepEqual(rec2020('color(rec2020 1 0 0 / 0.25)'), {
+test('color(rec2020)', t => {
+	assert.deepEqual(rec2020('color(rec2020 1 0 0 / 0.25)'), {
 		r: 1,
 		g: 0,
 		b: 0,
 		alpha: 0.25,
 		mode: 'rec2020'
 	});
-	t.deepEqual(rec2020('color(rec2020 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(rec2020('color(rec2020 0% 50% 0.5 / 25%)'), {
 		r: 0,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'rec2020'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(rec2020 0% 50% 0.5 / 25%)'),
 		'color(rec2020 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(rec2020 none 0.5 none)'), 'rec2020 to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(rec2020 none 0.5 none)'), 'rec2020 to rgb is ok');
+	assert.deepEqual(
 		rgb('color(rec2020 none 0.5 none)'),
 		rgb('color(rec2020 0 0.5 0')
 	);
-	t.ok(rec2020('rgb(none 100 20)'), 'rgb to rec2020 is ok');
-	t.deepEqual(rec2020('rgb(none 100 20)'), rec2020('rgb(0 100 20)'));
-	t.end();
+	assert.ok(rec2020('rgb(none 100 20)'), 'rgb to rec2020 is ok');
+	assert.deepEqual(rec2020('rgb(none 100 20)'), rec2020('rgb(0 100 20)'));
 });

--- a/test/rgb.test.js
+++ b/test/rgb.test.js
@@ -1,60 +1,57 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { rgb, formatHex, formatCss } from '../src/index.js';
 
-tape('rgb(Specifier)', function (test) {
-	test.deepEqual(formatHex(rgb('#ffffff')), '#ffffff');
+test('rgb(Specifier)', t => {
+	assert.deepEqual(formatHex(rgb('#ffffff')), '#ffffff');
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb('tomato'),
 		{ r: 1, g: 0.38823529411764707, b: 0.2784313725490196, mode: 'rgb' },
 		'named color'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb('rgb(255, 0, 0)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgb()'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb('rgba(255, 0, 0)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgba()'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb('rgb(100%, 0%, 0%)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgb()'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb('rgba(100%, 0%, 0%)'),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'rgba()'
 	);
-
-	test.end();
 });
 
-tape('rgb(Object)', function (test) {
-	test.deepEqual(
+test('rgb(Object)', t => {
+	assert.deepEqual(
 		rgb({ r: 1, g: 0, b: 0 }),
 		{ r: 1, g: 0, b: 0, mode: 'rgb' },
 		'red'
 	);
 
-	test.deepEqual(
+	assert.deepEqual(
 		rgb({ r: 0.1, g: 0.2, b: 0.3, alpha: 0.4 }),
 		{ r: 0.1, g: 0.2, b: 0.3, alpha: 0.4, mode: 'rgb' },
 		'floating point'
 	);
-
-	test.end();
 });
 
-tape('color(srgb)', t => {
-	t.deepEqual(
+test('color(srgb)', t => {
+	assert.deepEqual(
 		rgb('color(srgb 1 0 0 / 0.25)'),
 		{
 			r: 1,
@@ -65,45 +62,42 @@ tape('color(srgb)', t => {
 		},
 		'color(srgb 1 0 0 / 0.25)'
 	);
-	t.deepEqual(rgb('color(srgb 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(rgb('color(srgb 0% 50% 0.5 / 25%)'), {
 		r: 0,
 		g: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'rgb'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss(rgb('color(srgb 1 0 0.5/1)')),
 		'color(srgb 1 0 0.5)',
 		'color(srgb 1 0 0.5/1)'
 	);
-	t.end();
 });
 
 /*
 	See: https://emnudge.dev/blog/perfect-rgb-regex/
 */
-tape('exotic species', t => {
-	t.equal(
+test('exotic species', t => {
+	assert.equal(
 		formatCss(rgb('rgb(1-2-3)')),
 		'color(srgb 0.00392156862745098 -0.00784313725490196 -0.011764705882352941)'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(rgb('rgb(1-.2.3)')),
 		'color(srgb 0.00392156862745098 -0.0007843137254901962 0.001176470588235294)'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(rgb('rgb(1 .2.3)')),
 		'color(srgb 0.00392156862745098 0.0007843137254901962 0.001176470588235294)'
 	);
-	t.equal(
+	assert.equal(
 		formatCss(rgb('rgb(.1.2.3)')),
 		'color(srgb 0.0003921568627450981 0.0007843137254901962 0.001176470588235294)'
 	);
-	t.equal(formatCss(rgb('rgb(1.2.3)')), undefined);
-	t.end();
+	assert.equal(formatCss(rgb('rgb(1.2.3)')), undefined);
 });

--- a/test/samples.test.js
+++ b/test/samples.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { interpolate, samples, formatHex } from '../src/index.js';
 
-tape('11 swatches between black and white in RGB', function (test) {
-	test.deepEqual(
+test('11 swatches between black and white in RGB', t => {
+	assert.deepEqual(
 		samples(11)
 			.map(interpolate(['#fff', '#000']))
 			.map(formatHex),
@@ -20,12 +21,10 @@ tape('11 swatches between black and white in RGB', function (test) {
 			'#000000'
 		]
 	);
-
-	test.end();
 });
 
-tape('11 swatches between black and white in Lab', function (test) {
-	test.deepEqual(
+test('11 swatches between black and white in Lab', t => {
+	assert.deepEqual(
 		samples(11)
 			.map(interpolate(['#fff', '#000'], 'lab'))
 			.map(formatHex),
@@ -43,12 +42,10 @@ tape('11 swatches between black and white in Lab', function (test) {
 			'#000000'
 		]
 	);
-
-	test.end();
 });
 
-tape('11 swatches between black and white in Lch', function (test) {
-	test.deepEqual(
+test('11 swatches between black and white in Lch', t => {
+	assert.deepEqual(
 		samples(11)
 			.map(interpolate(['#fff', '#000'], 'lch'))
 			.map(formatHex),
@@ -66,12 +63,10 @@ tape('11 swatches between black and white in Lch', function (test) {
 			'#000000'
 		]
 	);
-
-	test.end();
 });
 
-tape('11 swatches between black and white in DIN99o', function (test) {
-	test.deepEqual(
+test('11 swatches between black and white in DIN99o', t => {
+	assert.deepEqual(
 		samples(11)
 			.map(interpolate(['#fff', '#000'], 'dlab'))
 			.map(formatHex),
@@ -90,15 +85,13 @@ tape('11 swatches between black and white in DIN99o', function (test) {
 		]
 	);
 
-	// test.deepEqual(
+	// assert.deepEqual(
 	// 	samples(11).map(interpolate(['red', 'white'], 'dlch')).map(formatHex),
 	// 	[]
 	// )
-
-	test.end();
 });
 
-// tape('default cubehelix scale', function(test) {
+// test('default cubehelix scale', function(test) {
 
 // 	let start = cubehelix({
 // 		h: 300,
@@ -112,10 +105,10 @@ tape('11 swatches between black and white in DIN99o', function (test) {
 // 		l: 1
 // 	})
 
-// 	test.deepEqual(
+// 	assert.deepEqual(
 // 		samples(10).map(interpolate([start, end], 'cubehelix')).map(formatHex),
 // 		['#000000', '#1a1935', '#15474e', '#2b6f39', '#767b33', '#c17a6f', '#d490c6', '#c3c0f2', '#ceebef', '#ffffff']
 // 	)
 
-// 	test.end();
+// 	;
 // });

--- a/test/wcag.test.js
+++ b/test/wcag.test.js
@@ -1,16 +1,15 @@
-import { luminance, contrast } from '../src/wcag.js';
-import tape from 'tape';
+import { wcagLuminance, wcagContrast } from '../src/index.js';
+import test from 'node:test';
+import assert from 'node:assert';
 
-tape('luminance', t => {
-	t.equal(luminance('white'), 1);
-	t.equal(luminance('black'), 0);
-	t.equal(luminance('#999'), 0.31854677812509186);
-	t.end();
+test('wcagLuminance', t => {
+	assert.equal(wcagLuminance('white'), 1);
+	assert.equal(wcagLuminance('black'), 0);
+	assert.equal(wcagLuminance('#999'), 0.31854677812509186);
 });
 
-tape('contrast', t => {
-	t.equal(contrast('black', 'white'), 21);
-	t.equal(contrast('white', 'black'), 21);
-	t.equal(contrast('red', 'red'), 1);
-	t.end();
+test('wcagContrast', t => {
+	assert.equal(wcagContrast('black', 'white'), 21);
+	assert.equal(wcagContrast('white', 'black'), 21);
+	assert.equal(wcagContrast('red', 'red'), 1);
 });

--- a/test/xyb.test.js
+++ b/test/xyb.test.js
@@ -1,61 +1,63 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { xyb, rgb, formatRgb, formatCss } from '../src/index.js';
 
-tape('rgb -> xyb', t => {
-	t.deepEqual(xyb('purple'), {
+test('rgb -> xyb', t => {
+	assert.deepEqual(xyb('purple'), {
 		mode: 'xyb',
 		x: 0.013838974535428816,
 		y: 0.27055837298918495,
 		b: 0.1333134464452821
 	});
-	t.end();
 });
 
-tape('rgb -> xyb -> rgb', t => {
-	t.deepEqual(
+test('rgb -> xyb -> rgb', t => {
+	assert.deepEqual(
 		formatRgb(xyb('rgb(255, 255, 255)')),
 		'rgb(255, 255, 255)',
 		'white'
 	);
 
-	t.deepEqual(formatRgb(xyb('rgb(0, 0, 0)')), 'rgb(0, 0, 0)', 'black');
-	t.deepEqual(formatRgb(xyb('rgb(100, 0, 0)')), 'rgb(100, 0, 0)', 'red');
-	t.deepEqual(formatRgb(xyb('rgb(0, 120, 0)')), 'rgb(0, 120, 0)', 'blue');
-	t.deepEqual(formatRgb(xyb('rgb(0, 0, 89)')), 'rgb(0, 0, 89)', 'green');
-
-	t.end();
+	assert.deepEqual(formatRgb(xyb('rgb(0, 0, 0)')), 'rgb(0, 0, 0)', 'black');
+	assert.deepEqual(formatRgb(xyb('rgb(100, 0, 0)')), 'rgb(100, 0, 0)', 'red');
+	assert.deepEqual(
+		formatRgb(xyb('rgb(0, 120, 0)')),
+		'rgb(0, 120, 0)',
+		'blue'
+	);
+	assert.deepEqual(formatRgb(xyb('rgb(0, 0, 89)')), 'rgb(0, 0, 89)', 'green');
 });
 
-tape('color(--xyb)', t => {
-	t.deepEqual(xyb('color(--xyb 1 0 0 / 0.25)'), {
+test('color(--xyb)', t => {
+	assert.deepEqual(xyb('color(--xyb 1 0 0 / 0.25)'), {
 		x: 1,
 		y: 0,
 		b: 0,
 		alpha: 0.25,
 		mode: 'xyb'
 	});
-	t.deepEqual(xyb('color(--xyb 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(xyb('color(--xyb 0% 50% 0.5 / 25%)'), {
 		x: 0,
 		y: 0.5,
 		b: 0.5,
 		alpha: 0.25,
 		mode: 'xyb'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--xyb 0% 50% 0.5 / 25%)'),
 		'color(--xyb 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--xyb none 0.5 none)'), 'xyb to rgb is ok');
-	t.deepEqual(rgb('color(--xyb none 0.5 none)'), rgb('color(--xyb 0 0.5 0'));
-	t.ok(xyb('rgb(none 100 20)'), 'rgb to xyb is ok');
-	t.deepEqual(xyb('rgb(none 100 20)'), xyb('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('color(--xyb none 0.5 none)'), 'xyb to rgb is ok');
+	assert.deepEqual(
+		rgb('color(--xyb none 0.5 none)'),
+		rgb('color(--xyb 0 0.5 0')
+	);
+	assert.ok(xyb('rgb(none 100 20)'), 'rgb to xyb is ok');
+	assert.deepEqual(xyb('rgb(none 100 20)'), xyb('rgb(0 100 20)'));
 });

--- a/test/xyz50.test.js
+++ b/test/xyz50.test.js
@@ -1,8 +1,9 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { xyz50, rgb, formatCss } from '../src/index.js';
 
-tape('xyz50', t => {
-	t.deepEqual(
+test('xyz50', t => {
+	assert.deepEqual(
 		xyz50('white'),
 		{
 			mode: 'xyz50',
@@ -12,8 +13,8 @@ tape('xyz50', t => {
 		},
 		'white'
 	);
-	t.deepEqual(xyz50('black'), { mode: 'xyz50', x: 0, y: 0, z: 0 });
-	t.deepEqual(
+	assert.deepEqual(xyz50('black'), { mode: 'xyz50', x: 0, y: 0, z: 0 });
+	assert.deepEqual(
 		xyz50('red'),
 		{
 			mode: 'xyz50',
@@ -23,7 +24,7 @@ tape('xyz50', t => {
 		},
 		'red'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		xyz50('#00cc0080'),
 		{
 			mode: 'xyz50',
@@ -34,47 +35,42 @@ tape('xyz50', t => {
 		},
 		'#00cc0080'
 	);
-	t.end();
 });
 
-tape('color(xyz-d50)', t => {
-	t.deepEqual(xyz50('color(xyz-d50 1 0 0 / 0.25)'), {
+test('color(xyz-d50)', t => {
+	assert.deepEqual(xyz50('color(xyz-d50 1 0 0 / 0.25)'), {
 		x: 1,
 		y: 0,
 		z: 0,
 		alpha: 0.25,
 		mode: 'xyz50'
 	});
-	t.deepEqual(xyz50('color(xyz-d50 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(xyz50('color(xyz-d50 0% 50% 0.5 / 25%)'), {
 		x: 0,
 		y: 0.5,
 		z: 0.5,
 		alpha: 0.25,
 		mode: 'xyz50'
 	});
-	t.end();
 });
 
-tape('color(--xyz-d50)', t => {
-	t.deepEqual(xyz50('color(--xyz-d50 1 0 0 / 0.25)'), undefined);
-	t.end();
+test('color(--xyz-d50)', t => {
+	assert.deepEqual(xyz50('color(--xyz-d50 1 0 0 / 0.25)'), undefined);
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(xyz-d50 0% 50% 0.5 / 25%)'),
 		'color(xyz-d50 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(xyz-d50 none 0.5 none)'), 'xyz50 to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(xyz-d50 none 0.5 none)'), 'xyz50 to rgb is ok');
+	assert.deepEqual(
 		rgb('color(xyz-d50 none 0.5 none)'),
 		rgb('color(xyz-d50 0 0.5 0')
 	);
-	t.ok(xyz50('rgb(none 100 20)'), 'rgb to xyz50 is ok');
-	t.deepEqual(xyz50('rgb(none 100 20)'), xyz50('rgb(0 100 20)'));
-	t.end();
+	assert.ok(xyz50('rgb(none 100 20)'), 'rgb to xyz50 is ok');
+	assert.deepEqual(xyz50('rgb(none 100 20)'), xyz50('rgb(0 100 20)'));
 });

--- a/test/xyz65.test.js
+++ b/test/xyz65.test.js
@@ -1,12 +1,13 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { xyz65, rgb, formatCss } from '../src/index.js';
 
-tape('xyz65', t => {
+test('xyz65', t => {
 	/*
 		These should theoretically be equal to the Xn, Yn, and Zn values
 		from xyz65/constants.js, but there's a small rounding error for `y`.
 	 */
-	t.deepEqual(
+	assert.deepEqual(
 		xyz65('white'),
 		{
 			mode: 'xyz65',
@@ -17,8 +18,8 @@ tape('xyz65', t => {
 		'white'
 	);
 
-	t.deepEqual(xyz65('black'), { mode: 'xyz65', x: 0, y: 0, z: 0 });
-	t.deepEqual(
+	assert.deepEqual(xyz65('black'), { mode: 'xyz65', x: 0, y: 0, z: 0 });
+	assert.deepEqual(
 		xyz65('red'),
 		{
 			mode: 'xyz65',
@@ -28,7 +29,7 @@ tape('xyz65', t => {
 		},
 		'red'
 	);
-	t.deepEqual(
+	assert.deepEqual(
 		xyz65('#00cc0080'),
 		{
 			mode: 'xyz65',
@@ -39,65 +40,59 @@ tape('xyz65', t => {
 		},
 		'#00cc0080'
 	);
-	t.end();
 });
 
-tape('color(xyz)', t => {
-	t.deepEqual(xyz65('color(xyz 1 0 0 / 0.25)'), {
+test('color(xyz)', t => {
+	assert.deepEqual(xyz65('color(xyz 1 0 0 / 0.25)'), {
 		x: 1,
 		y: 0,
 		z: 0,
 		alpha: 0.25,
 		mode: 'xyz65'
 	});
-	t.deepEqual(xyz65('color(xyz 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(xyz65('color(xyz 0% 50% 0.5 / 25%)'), {
 		x: 0,
 		y: 0.5,
 		z: 0.5,
 		alpha: 0.25,
 		mode: 'xyz65'
 	});
-	t.end();
 });
 
-tape('color(xyz-d65)', t => {
-	t.deepEqual(xyz65('color(xyz-d65 1 0 0 / 0.25)'), {
+test('color(xyz-d65)', t => {
+	assert.deepEqual(xyz65('color(xyz-d65 1 0 0 / 0.25)'), {
 		x: 1,
 		y: 0,
 		z: 0,
 		alpha: 0.25,
 		mode: 'xyz65'
 	});
-	t.deepEqual(xyz65('color(xyz-d65 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(xyz65('color(xyz-d65 0% 50% 0.5 / 25%)'), {
 		x: 0,
 		y: 0.5,
 		z: 0.5,
 		alpha: 0.25,
 		mode: 'xyz65'
 	});
-	t.end();
 });
 
-tape('color(--xyz-d65)', t => {
-	t.deepEqual(xyz65('color(--xyz-d65 1 0 0 / 0.25)'), undefined);
-	t.end();
+test('color(--xyz-d65)', t => {
+	assert.deepEqual(xyz65('color(--xyz-d65 1 0 0 / 0.25)'), undefined);
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(xyz 0% 50% 0.5 / 25%)'),
 		'color(xyz-d65 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(xyz-d65 none 0.5 none)'), 'xyz65 to rgb is ok');
-	t.deepEqual(
+test('missing components', t => {
+	assert.ok(rgb('color(xyz-d65 none 0.5 none)'), 'xyz65 to rgb is ok');
+	assert.deepEqual(
 		rgb('color(xyz-d65 none 0.5 none)'),
 		rgb('color(xyz-d65 0 0.5 0')
 	);
-	t.ok(xyz65('rgb(none 100 20)'), 'rgb to xyz65 is ok');
-	t.deepEqual(xyz65('rgb(none 100 20)'), xyz65('rgb(0 100 20)'));
-	t.end();
+	assert.ok(xyz65('rgb(none 100 20)'), 'rgb to xyz65 is ok');
+	assert.deepEqual(xyz65('rgb(none 100 20)'), xyz65('rgb(0 100 20)'));
 });

--- a/test/yiq.test.js
+++ b/test/yiq.test.js
@@ -1,61 +1,63 @@
-import tape from 'tape';
+import test from 'node:test';
+import assert from 'node:assert';
 import { yiq, rgb, formatRgb, formatCss } from '../src/index.js';
 
-tape('rgb -> yiq', t => {
-	t.deepEqual(yiq('purple'), {
+test('rgb -> yiq', t => {
+	assert.deepEqual(yiq('purple'), {
 		mode: 'yiq',
 		y: 0.20749931419607845,
 		i: 0.13762565019607842,
 		q: 0.26233329443137254
 	});
-	t.end();
 });
 
-tape('rgb -> yiq -> rgb', t => {
-	t.deepEqual(
+test('rgb -> yiq -> rgb', t => {
+	assert.deepEqual(
 		formatRgb(yiq('rgb(255, 255, 255)')),
 		'rgb(255, 255, 255)',
 		'white'
 	);
 
-	t.deepEqual(formatRgb(yiq('rgb(0, 0, 0)')), 'rgb(0, 0, 0)', 'black');
-	t.deepEqual(formatRgb(yiq('rgb(100, 0, 0)')), 'rgb(100, 0, 0)', 'red');
-	t.deepEqual(formatRgb(yiq('rgb(0, 120, 0)')), 'rgb(0, 120, 0)', 'blue');
-	t.deepEqual(formatRgb(yiq('rgb(0, 0, 89)')), 'rgb(0, 0, 89)', 'green');
-
-	t.end();
+	assert.deepEqual(formatRgb(yiq('rgb(0, 0, 0)')), 'rgb(0, 0, 0)', 'black');
+	assert.deepEqual(formatRgb(yiq('rgb(100, 0, 0)')), 'rgb(100, 0, 0)', 'red');
+	assert.deepEqual(
+		formatRgb(yiq('rgb(0, 120, 0)')),
+		'rgb(0, 120, 0)',
+		'blue'
+	);
+	assert.deepEqual(formatRgb(yiq('rgb(0, 0, 89)')), 'rgb(0, 0, 89)', 'green');
 });
 
-tape('color(--yiq)', t => {
-	t.deepEqual(yiq('color(--yiq 1 0 0 / 0.25)'), {
+test('color(--yiq)', t => {
+	assert.deepEqual(yiq('color(--yiq 1 0 0 / 0.25)'), {
 		y: 1,
 		i: 0,
 		q: 0,
 		alpha: 0.25,
 		mode: 'yiq'
 	});
-	t.deepEqual(yiq('color(--yiq 0% 50% 0.5 / 25%)'), {
+	assert.deepEqual(yiq('color(--yiq 0% 50% 0.5 / 25%)'), {
 		y: 0,
 		i: 0.5,
 		q: 0.5,
 		alpha: 0.25,
 		mode: 'yiq'
 	});
-	t.end();
 });
 
-tape('formatCss', t => {
-	t.equal(
+test('formatCss', t => {
+	assert.equal(
 		formatCss('color(--yiq 0% 50% 0.5 / 25%)'),
 		'color(--yiq 0 0.5 0.5 / 0.25)'
 	);
-	t.end();
 });
 
-tape('missing components', t => {
-	t.ok(rgb('color(--yiq none 0.5 none)'), 'yiq to rgb is ok');
-	t.deepEqual(rgb('color(--yiq none 0.5 none)'), rgb('color(--yiq 0 0.5 0'));
-	t.ok(yiq('rgb(none 100 20)'), 'rgb to yiq is ok');
-	t.deepEqual(yiq('rgb(none 100 20)'), yiq('rgb(0 100 20)'));
-	t.end();
+test('missing components', t => {
+	assert.ok(rgb('color(--yiq none 0.5 none)'), 'yiq to rgb is ok');
+	assert.deepEqual(
+		rgb('color(--yiq none 0.5 none)'),
+		rgb('color(--yiq 0 0.5 0')
+	);
+	assert.ok(yiq('rgb(none 100 20)'), 'rgb to yiq is ok');
+	assert.deepEqual(yiq('rgb(none 100 20)'), yiq('rgb(0 100 20)'));
 });


### PR DESCRIPTION
A first pass at converting tests from `tape` to native Node. Fixes #224.

Note: running the tests requires Node 21 to allow globstar patterns in `npm` scripts (see https://github.com/nodejs/node/issues/50658).