### PR TITLE
Feature/add din99c and din99d

### DIFF
--- a/docs/color-spaces.md
+++ b/docs/color-spaces.md
@@ -277,6 +277,51 @@ Serialized as `color(--din99o-lch l c h)`, with the `none` keyword for any missi
 
 Does not have gamut limits.
 
+### DIN99c and DIN99d
+
+DIN99c and DIN99d are "spinoffs" of DIN99b which itself is derived from DIN99. For color distance calculation they are said to perform better than DIN99o, especially in the blue areas, and are comparable in quality to the complex CIE2000 formula.
+
+The sole purpose of these color spaces is highly performant distance calculation, so only conversion _to_ DIN99c/d is implemented.
+The models also contains chroma and hue channels as supporting information.
+
+The color distance (deltaE) function factories are:
+```js
+culori.differenceEuclidean('d99c')
+culori.differenceEuclidean('d99d')
+```
+If needed outside of culori, distance calculation is:<br>
+```text
+&Delta;E = SQRT( &Delta;L<sup>2</sup> + &Delta;a<sup>2</sup> + &Delta;b<sup>2</sup> )
+```
+
+#### `din99c`
+
+DIN99c color space in cartesian and cylindrical form.
+
+| Channel | Range                | Description |
+| ------- | -------------------- | ----------- |
+| `l`     | `[0, 100]`           | Lightness   |
+| `a`     | `[-55, 55]`≈         |
+| `b`     | `[-55, 55]`≈         |
+| `c`     | `[0, 55]`≈           | Chroma      |
+| `h`     | `[0, 360)`           | Hue         |
+
+Does not have gamut limits.
+
+#### `din99d`
+
+DIN99d color space in cartesian and cylindrical form.
+
+| Channel | Range                | Description |
+| ------- | -------------------- | ----------- |
+| `l`     | `[0, 100]`           | Lightness   |
+| `a`     | `[-55, 55]`≈         |
+| `b`     | `[-55, 55]`≈         |
+| `c`     | `[0, 55]`≈           | Chroma      |
+| `h`     | `[0, 360)`           | Hue         |
+
+Does not have gamut limits.
+
 ### Oklab, Oklch, Okhsl, Okhsv
 
 The [Oklab color space](https://bottosson.github.io/posts/oklab/), in Cartesian (Lab) and cylindrical (LCh) forms. It uses the D65 standard illuminant. 

--- a/src/d99c/constants.js
+++ b/src/d99c/constants.js
@@ -1,0 +1,2 @@
+export const kE = 1;
+export const θ = (26 / 180) * Math.PI;

--- a/src/d99c/constants.js
+++ b/src/d99c/constants.js
@@ -1,2 +1,1 @@
 export const kE = 1;
-export const θ = (26 / 180) * Math.PI;

--- a/src/d99c/convertXyz65ToD99c.js
+++ b/src/d99c/convertXyz65ToD99c.js
@@ -1,4 +1,4 @@
-import { kE, θ } from './constants.js';
+import { kE } from './constants.js';
 import convertXyz65ToLab65 from '../lab65/convertXyz65ToLab65.js';
 import normalizeHue from '../util/normalizeHue.js';
 

--- a/src/d99c/convertXyz65ToD99c.js
+++ b/src/d99c/convertXyz65ToD99c.js
@@ -1,0 +1,32 @@
+import { kE, θ } from './constants.js';
+import convertXyz65ToLab65 from '../lab65/convertXyz65ToLab65.js';
+import normalizeHue from '../util/normalizeHue.js';
+
+const convertXyz65ToD99c = ({ x, y, z, alpha }) => {
+    x = x || 0;
+    y =  y || 0;
+    z = z || 0;
+    const myX = 1.1 * x - 0.1 * z;
+    const myLab = convertXyz65ToLab65({ x: myX, y, z, alpha });
+    const L99c = (1 / kE) * 317.65 * Math.log(1 + 0.0037 * myLab.l);
+    const f = 0.94 * myLab.b;
+    const G = Math.sqrt(myLab.a * myLab.a + f * f);
+    const C99c = 23 * Math.log(1 + 0.066 * G);
+    const h99c = Math.atan2(f, myLab.a);
+    const a99c = C99c * Math.cos(h99c);
+    const b99c = C99c * Math.sin(h99c);
+
+    let res = {
+        mode: 'd99c',
+        l: L99c,
+        a: a99c,
+        b: b99c,
+        c: C99c,
+        h: normalizeHue(h99c * 180 / Math.PI)
+    };
+
+    if (alpha !== undefined) res.alpha = alpha;
+    return res;
+};
+
+export default convertXyz65ToD99c;

--- a/src/d99c/definition.js
+++ b/src/d99c/definition.js
@@ -7,6 +7,7 @@ import convertXyz65ToD99c from './convertXyz65ToD99c.js';
 import { interpolatorLinear } from '../interpolate/linear.js';
 import { fixupAlpha } from '../fixup/alpha.js';
 import { fixupHueShorter } from '../fixup/hue.js';
+import { differenceEuclidean } from '../difference.js';
 
 const definition = {
 	mode: 'd99c',
@@ -19,14 +20,13 @@ const definition = {
 		rgb: c => convertXyz65ToD99c(convertRgbToXyz65(c))
 	},
 
-	channels: ['l', 'a', 'b', 'c', 'h', 'alpha'],
+	channels: ['l', 'a', 'b', 'alpha'],
 
-	// TODO: check ranges
 	ranges: {
 		l: [0, 100],
-		a: [-40.09, 45.501],
-		b: [-40.469, 44.344],
-		c: [0, 51.484],
+		a: [-55, 55],
+		b: [-55, 55],
+		c: [0, 55],
 		h: [0, 360]
 	},
 
@@ -34,15 +34,14 @@ const definition = {
 		l: interpolatorLinear,
 		a: interpolatorLinear,
 		b: interpolatorLinear,
-		c: interpolatorLinear,
-		h: {
-			use: interpolatorLinear,
-			fixup: fixupHueShorter
-		},
 		alpha: {
 			use: interpolatorLinear,
 			fixup: fixupAlpha
 		}
+	},
+
+	difference: {
+		h: differenceEuclidean
 	}
 };
 

--- a/src/d99c/definition.js
+++ b/src/d99c/definition.js
@@ -6,7 +6,6 @@ import convertRgbToXyz65 from '../xyz65/convertRgbToXyz65.js';
 import convertXyz65ToD99c from './convertXyz65ToD99c.js';
 import { interpolatorLinear } from '../interpolate/linear.js';
 import { fixupAlpha } from '../fixup/alpha.js';
-import { fixupHueShorter } from '../fixup/hue.js';
 import { differenceEuclidean } from '../difference.js';
 
 const definition = {
@@ -17,6 +16,7 @@ const definition = {
 
 	fromMode: {
 		xyz65: convertXyz65ToD99c,
+		// @ts-ignore
 		rgb: c => convertXyz65ToD99c(convertRgbToXyz65(c))
 	},
 

--- a/src/d99c/definition.js
+++ b/src/d99c/definition.js
@@ -1,0 +1,49 @@
+/**
+ * Implements DIN99c
+ */
+
+import convertRgbToXyz65 from '../xyz65/convertRgbToXyz65.js';
+import convertXyz65ToD99c from './convertXyz65ToD99c.js';
+import { interpolatorLinear } from '../interpolate/linear.js';
+import { fixupAlpha } from '../fixup/alpha.js';
+import { fixupHueShorter } from '../fixup/hue.js';
+
+const definition = {
+	mode: 'd99c',
+
+	parse: ['--din99c-labch'],
+	serialize: '--din99c-labch',
+
+	fromMode: {
+		xyz65: convertXyz65ToD99c,
+		rgb: c => convertXyz65ToD99c(convertRgbToXyz65(c))
+	},
+
+	channels: ['l', 'a', 'b', 'c', 'h', 'alpha'],
+
+	// TODO: check ranges
+	ranges: {
+		l: [0, 100],
+		a: [-40.09, 45.501],
+		b: [-40.469, 44.344],
+		c: [0, 51.484],
+		h: [0, 360]
+	},
+
+	interpolate: {
+		l: interpolatorLinear,
+		a: interpolatorLinear,
+		b: interpolatorLinear,
+		c: interpolatorLinear,
+		h: {
+			use: interpolatorLinear,
+			fixup: fixupHueShorter
+		},
+		alpha: {
+			use: interpolatorLinear,
+			fixup: fixupAlpha
+		}
+	}
+};
+
+export default definition;

--- a/src/d99d/constants.js
+++ b/src/d99d/constants.js
@@ -1,0 +1,3 @@
+export const deg50 = 0.8726646259971648;
+export const sinDeg50 = 0.766044443118978;
+export const cosDeg50 = 0.6427876096865394;

--- a/src/d99d/convertXyz65ToD99d.js
+++ b/src/d99d/convertXyz65ToD99d.js
@@ -1,0 +1,34 @@
+import { deg50, sinDeg50, cosDeg50 } from './constants.js';
+import convertXyz65ToLab65 from '../lab65/convertXyz65ToLab65.js';
+import normalizeHue from '../util/normalizeHue.js';
+
+const convertXyz65ToD99d = ({ x, y, z, alpha }) => {
+    x = x || 0;
+    y = y || 0;
+    z = z || 0;
+    const myX = 1.12 * x - 0.12 * z;
+    const myLab = convertXyz65ToLab65({ x: myX, y, z, alpha });
+    const L99d = 325.22 * Math.log(1 + 0.0036 * myLab.l);
+    const e = myLab.a * cosDeg50 + myLab.b * sinDeg50;
+    const f = 1.14 * (myLab.b * cosDeg50 - myLab.a * sinDeg50);
+    const G = Math.sqrt(e * e + f * f);
+    const C99d = 22.5 * Math.log(1 + 0.06 * G);
+
+    const h99d = Math.atan2(f, e) + deg50;
+    const a99d = C99d * Math.cos(h99d);
+    const b99d = C99d * Math.sin(h99d);
+
+    let res = {
+        mode: 'd99d',
+        l: L99d,
+        a: a99d,
+        b: b99d,
+        c: C99d,
+        h: normalizeHue(h99d * 180 / Math.PI)
+    };
+
+    if (alpha !== undefined) res.alpha = alpha;
+    return res;
+};
+
+export default convertXyz65ToD99d;

--- a/src/d99d/definition.js
+++ b/src/d99d/definition.js
@@ -6,6 +6,7 @@ import convertRgbToXyz65 from '../xyz65/convertRgbToXyz65.js';
 import convertXyz65ToD99d from './convertXyz65ToD99d.js';
 import { interpolatorLinear } from '../interpolate/linear.js';
 import { fixupAlpha } from '../fixup/alpha.js';
+import { differenceEuclidean } from '../difference.js';
 
 const definition = {
 	mode: 'd99d',
@@ -20,11 +21,12 @@ const definition = {
 
 	channels: ['l', 'a', 'b', 'alpha'],
 
-	// TODO: check ranges
 	ranges: {
 		l: [0, 100],
-		a: [-40.09, 45.501],
-		b: [-40.469, 44.344]
+		a: [-55, 55],
+		b: [-55, 55],
+		c: [0, 55],
+		h: [0, 360]
 	},
 
 	interpolate: {
@@ -35,6 +37,10 @@ const definition = {
 			use: interpolatorLinear,
 			fixup: fixupAlpha
 		}
+	},
+
+	difference: {
+		h: differenceEuclidean
 	}
 };
 

--- a/src/d99d/definition.js
+++ b/src/d99d/definition.js
@@ -1,0 +1,41 @@
+/**
+ * Implements DIN99d
+ */
+
+import convertRgbToXyz65 from '../xyz65/convertRgbToXyz65.js';
+import convertXyz65ToD99d from './convertXyz65ToD99d.js';
+import { interpolatorLinear } from '../interpolate/linear.js';
+import { fixupAlpha } from '../fixup/alpha.js';
+
+const definition = {
+	mode: 'd99d',
+
+	parse: ['--din99d-labch'],
+	serialize: '--din99d-labch',
+
+	fromMode: {
+		xyz65: convertXyz65ToD99d,
+		rgb: c => convertXyz65ToD99d(convertRgbToXyz65(c))
+	},
+
+	channels: ['l', 'a', 'b', 'alpha'],
+
+	// TODO: check ranges
+	ranges: {
+		l: [0, 100],
+		a: [-40.09, 45.501],
+		b: [-40.469, 44.344]
+	},
+
+	interpolate: {
+		l: interpolatorLinear,
+		a: interpolatorLinear,
+		b: interpolatorLinear,
+		alpha: {
+			use: interpolatorLinear,
+			fixup: fixupAlpha
+		}
+	}
+};
+
+export default definition;

--- a/src/d99d/definition.js
+++ b/src/d99d/definition.js
@@ -16,6 +16,7 @@ const definition = {
 
 	fromMode: {
 		xyz65: convertXyz65ToD99d,
+		// @ts-ignore
 		rgb: c => convertXyz65ToD99d(convertRgbToXyz65(c))
 	},
 

--- a/src/index-fn.js
+++ b/src/index-fn.js
@@ -2,6 +2,8 @@
 export { default as modeA98 } from './a98/definition.js';
 export { default as modeCubehelix } from './cubehelix/definition.js';
 export { default as modeDlab } from './dlab/definition.js';
+export { default as moded99c } from './d99c/definition.js';
+export { default as modeD99d } from './d99d/definition.js';
 export { default as modeDlch } from './dlch/definition.js';
 export { default as modeHsi } from './hsi/definition.js';
 export { default as modeHsl } from './hsl/definition.js';
@@ -215,6 +217,8 @@ export { default as convertRgbToYiq } from './yiq/convertRgbToYiq.js';
 export { default as convertRgbToXyb } from './xyb/convertRgbToXyb.js';
 export { default as convertXybToRgb } from './xyb/convertXybToRgb.js';
 export { default as convertXyz65ToA98 } from './a98/convertXyz65ToA98.js';
+export { default as convertXyz65ToD99c } from './d99c/convertXyz65ToD99c';
+export { default as convertXyz65ToD99d } from './d99d/convertXyz65ToD99d';
 export { default as convertXyz65ToItp } from './itp/convertXyz65ToItp.js';
 export { default as convertXyz65ToJab } from './jab/convertXyz65ToJab.js';
 export { default as convertXyz65ToLab65 } from './lab65/convertXyz65ToLab65.js';

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,8 @@
 import modeA98 from './a98/definition.js';
 import modeCubehelix from './cubehelix/definition.js';
 import modeDlab from './dlab/definition.js';
+import moded99c from './d99c/definition.js';
+import modeD99d from './d99d/definition.js';
 import modeDlch from './dlch/definition.js';
 import modeHsi from './hsi/definition.js';
 import modeHsl from './hsl/definition.js';
@@ -221,6 +223,8 @@ export { default as convertXyz50ToProphoto } from './prophoto/convertXyz50ToProp
 export { default as convertXyz50ToRgb } from './xyz50/convertXyz50ToRgb.js';
 export { default as convertXyz50ToXyz65 } from './xyz65/convertXyz50ToXyz65.js';
 export { default as convertXyz65ToA98 } from './a98/convertXyz65ToA98.js';
+export { default as convertXyz65ToD99c } from './d99c/convertXyz65ToD99c';
+export { default as convertXyz65ToD99d } from './d99d/convertXyz65ToD99d';
 export { default as convertXyz65ToItp } from './itp/convertXyz65ToItp.js';
 export { default as convertXyz65ToJab } from './jab/convertXyz65ToJab.js';
 export { default as convertXyz65ToLab65 } from './lab65/convertXyz65ToLab65.js';
@@ -234,6 +238,8 @@ export {
 	modeA98,
 	modeCubehelix,
 	modeDlab,
+	moded99c,
+	modeD99d,
 	modeDlch,
 	modeHsi,
 	modeHsl,
@@ -266,6 +272,8 @@ export {
 export const a98 = useMode(modeA98);
 export const cubehelix = useMode(modeCubehelix);
 export const dlab = useMode(modeDlab);
+export const d99c = useMode(moded99c);
+export const d99d = useMode(modeD99d);
 export const dlch = useMode(modeDlch);
 export const hsi = useMode(modeHsi);
 export const hsl = useMode(modeHsl);


### PR DESCRIPTION
### DRAFT

Features DIN99c and DIN99d.
I'm unsure whether I understood all the internal culori concepts. It works, though.

Tests are still missing (WIP). Main problem: There are no publicly available examples for specific colors in DIN99c or DIN99d; We'd just have to trust the formula transcription was correct.
The according deltaE tests should also be added.

If conversion _back_ from these color spaces is really necessary someone else would have to do the math; That's beyond my capabilities.

GIT commit messages follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).